### PR TITLE
Add advantage/disadvantage roll support

### DIFF
--- a/src/components/modifierBox/componentInitializer.js
+++ b/src/components/modifierBox/componentInitializer.js
@@ -17,7 +17,11 @@ import {
   updateSelectedModifier as updateSelectedModifierFromRowManager,
   loadModifierRows,
 } from './rowManager.js';
-import { setupMinimizeControls, setupClearAllControls } from './uiControls.js';
+import {
+  setupMinimizeControls,
+  setupAdvantageControls,
+  setupClearAllControls,
+} from './uiControls.js';
 
 export function setupModifierBoxComponents(modifierBox, clearAllCallback) {
   if (!modifierBox) {
@@ -140,6 +144,7 @@ function setupRowManagement(modifierBox) {
 
 function setupUIControls(modifierBox, clearAllCallback) {
   setupMinimizeControls(modifierBox);
+  setupAdvantageControls(modifierBox);
 
   if (clearAllCallback) {
     setupClearAllControls(modifierBox, clearAllCallback);

--- a/src/components/modifierBox/modifierBox.html
+++ b/src/components/modifierBox/modifierBox.html
@@ -47,5 +47,31 @@
       <button class="remove-row-btn" type="button">×</button>
     </div>
   </div>
+  <div class="pixels-advantage-footer">
+    <span class="pixels-advantage-label">Roll:</span>
+    <div class="pixels-advantage-buttons">
+      <button
+        class="advantage-btn active"
+        data-type="normal"
+        title="Single roll"
+      >
+        Normal
+      </button>
+      <button
+        class="advantage-btn"
+        data-type="advantage"
+        title="Roll twice, take higher (Advantage)"
+      >
+        Adv
+      </button>
+      <button
+        class="advantage-btn"
+        data-type="disadvantage"
+        title="Roll twice, take lower (Disadvantage)"
+      >
+        Dis
+      </button>
+    </div>
+  </div>
   <div class="pixels-resize-handle"></div>
 </div>

--- a/src/components/modifierBox/modifierBox.js
+++ b/src/components/modifierBox/modifierBox.js
@@ -227,6 +227,14 @@ function createModifierBoxFallback() {
                     <button class="remove-row-btn" type="button">×</button>
                 </div>
             </div>
+            <div class="pixels-advantage-footer">
+                <span class="pixels-advantage-label">Roll:</span>
+                <div class="pixels-advantage-buttons">
+                    <button class="advantage-btn active" data-type="normal" title="Single roll">Normal</button>
+                    <button class="advantage-btn" data-type="advantage" title="Roll twice, take higher (Advantage)">Adv</button>
+                    <button class="advantage-btn" data-type="disadvantage" title="Roll twice, take lower (Disadvantage)">Dis</button>
+                </div>
+            </div>
             <div class="pixels-resize-handle"></div>
         `;
 

--- a/src/components/modifierBox/styles/lightTheme.css
+++ b/src/components/modifierBox/styles/lightTheme.css
@@ -97,3 +97,32 @@
     transparent 70%
   ) !important;
 }
+
+/* Light Theme: Advantage/Disadvantage Footer */
+.roll20-light-theme #pixels-modifier-box .pixels-advantage-footer {
+  background-color: #f8f9fa !important;
+  border-top-color: #dddddd !important;
+}
+
+.roll20-light-theme #pixels-modifier-box .pixels-advantage-label {
+  color: #666666 !important;
+}
+
+.roll20-light-theme #pixels-modifier-box .advantage-btn {
+  color: #555555 !important;
+  background-color: #ffffff !important;
+  border-color: #cccccc !important;
+}
+
+.roll20-light-theme #pixels-modifier-box .advantage-btn:hover {
+  background-color: #e9ecef !important;
+  color: #333333 !important;
+}
+
+.roll20-light-theme
+  #pixels-modifier-box
+  .advantage-btn.active[data-type='normal'] {
+  background-color: #e9ecef !important;
+  border-color: #666666 !important;
+  color: #333333 !important;
+}

--- a/src/components/modifierBox/styles/modifierBox.css
+++ b/src/components/modifierBox/styles/modifierBox.css
@@ -401,3 +401,67 @@
   min-width: 24px !important;
   padding: 0 !important;
 }
+
+/* Advantage/Disadvantage Footer */
+#pixels-modifier-box .pixels-advantage-footer {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 8px !important;
+  padding: 8px 16px !important;
+  border-top: 1px solid #555555 !important;
+  background-color: #2b2b2b !important;
+  border-radius: 0 0 7px 7px !important;
+  flex-shrink: 0 !important;
+}
+
+#pixels-modifier-box .pixels-advantage-label {
+  font-size: 12px !important;
+  color: #aaaaaa !important;
+  font-weight: bold !important;
+}
+
+#pixels-modifier-box .pixels-advantage-buttons {
+  display: flex !important;
+  gap: 4px !important;
+}
+
+#pixels-modifier-box .advantage-btn {
+  padding: 3px 10px !important;
+  border-radius: 4px !important;
+  border: 1px solid #555555 !important;
+  font-size: 12px !important;
+  font-weight: bold !important;
+  cursor: pointer !important;
+  color: #aaaaaa !important;
+  background-color: #333333 !important;
+  transition: all 0.2s ease !important;
+}
+
+#pixels-modifier-box .advantage-btn:hover {
+  border-color: #888888 !important;
+  color: #ffffff !important;
+}
+
+#pixels-modifier-box .advantage-btn.active[data-type='normal'] {
+  background-color: #444444 !important;
+  border-color: #888888 !important;
+  color: #ffffff !important;
+}
+
+#pixels-modifier-box .advantage-btn.active[data-type='advantage'] {
+  background-color: #1b5e20 !important;
+  border-color: #4caf50 !important;
+  color: #4caf50 !important;
+}
+
+#pixels-modifier-box .advantage-btn.active[data-type='disadvantage'] {
+  background-color: #b71c1c !important;
+  border-color: #f44336 !important;
+  color: #f44336 !important;
+}
+
+/* Hide footer when minimized */
+#pixels-modifier-box.minimized .pixels-advantage-footer {
+  display: none !important;
+}

--- a/src/components/modifierBox/uiControls.js
+++ b/src/components/modifierBox/uiControls.js
@@ -66,6 +66,32 @@ function restoreModifierBox(modifierBox, minimizeBtn) {
   minimizeBtn.title = 'Minimize';
 }
 
+export function setupAdvantageControls(modifierBox) {
+  if (!modifierBox) return;
+  const buttons = modifierBox.querySelectorAll('.advantage-btn');
+  if (!buttons.length) return;
+
+  // Restore persisted roll type
+  const saved = localStorage.getItem('pixels_roll_type') || 'normal';
+  window.pixelsRollType = saved;
+  buttons.forEach(btn =>
+    btn.classList.toggle('active', btn.dataset.type === saved)
+  );
+
+  buttons.forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      e.stopPropagation();
+      const type = btn.dataset.type;
+      window.pixelsRollType = type;
+      localStorage.setItem('pixels_roll_type', type);
+      buttons.forEach(b =>
+        b.classList.toggle('active', b.dataset.type === type)
+      );
+    });
+  });
+}
+
 export function setupClearAllControls(modifierBox, clearAllCallback) {
   if (!modifierBox) {
     console.error('setupClearAllControls: modifierBox is required');
@@ -92,6 +118,7 @@ export function setupClearAllControls(modifierBox, clearAllCallback) {
 
 const UIControls = {
   setupMinimizeControls,
+  setupAdvantageControls,
   setupClearAllControls,
 };
 

--- a/src/content/modules/PixelsBluetooth.js
+++ b/src/content/modules/PixelsBluetooth.js
@@ -121,6 +121,9 @@ export const createPixel = (name, server, device) => {
     }, 30000); // Check every 30 seconds - less frequent since we're only checking GATT state
   };
 
+  let _pendingAdvantageRoll = null; // first roll value when waiting for second
+  let _advantageTimeout = null; // timer to cancel if no second roll arrives
+
   let _disconnectionTimeout = null;
   let _pixelSelf = null; // Store reference to self for reconnection
 
@@ -215,7 +218,7 @@ export const createPixel = (name, server, device) => {
       }
     } else if (ev === 1) {
       _face = face;
-      const txt = `${_name}: face up = ${face + 1}`;
+      const diceValue = face + 1;
 
       // Check if modifier box is visible to determine modifier application
       const isModifierBoxVisible =
@@ -232,44 +235,121 @@ export const createPixel = (name, server, device) => {
         window.ModifierBox.syncGlobalVars();
       }
 
-      const diceValue = face + 1;
-      const modifier = isModifierBoxVisible
-        ? parseInt(window.pixelsModifier) || 0
-        : 0;
-      const result = diceValue + modifier;
+      const rollType = window.pixelsRollType || 'normal';
 
-      // Choose formula based on modifier box visibility
-      let formula = isModifierBoxVisible
-        ? pixelsFormulaWithModifier
-        : pixelsFormulaSimple;
+      if (rollType === 'advantage' || rollType === 'disadvantage') {
+        if (_pendingAdvantageRoll === null) {
+          // ── ROLL 1: buffer and wait for roll 2 ──
+          _pendingAdvantageRoll = diceValue;
+          sendTextToExtension(
+            `${_name}: Roll 1 = ${diceValue} — waiting for roll 2…`
+          );
 
-      // Add critical hit message if face value is 20
-      if (diceValue === 20 && isModifierBoxVisible) {
-        formula = formula.replace(
-          '{{Pixel=#face_value}}',
-          '{{&#128293; <span style="color: #ff4444; font-size: 20px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.5);">CRITICAL!</span> &#128293;}} {{Pixel=#face_value}}'
-        );
+          // Cancel if no second roll arrives within 15 seconds
+          _advantageTimeout = setTimeout(() => {
+            _pendingAdvantageRoll = null;
+            _advantageTimeout = null;
+            sendTextToExtension(
+              `${_name}: Timed out waiting for roll 2 — roll cancelled`
+            );
+          }, 15000);
+        } else {
+          // ── ROLL 2: compute and post result ──
+          clearTimeout(_advantageTimeout);
+          _advantageTimeout = null;
+
+          const roll1 = _pendingAdvantageRoll;
+          const roll2 = diceValue;
+          _pendingAdvantageRoll = null;
+
+          const usedValue =
+            rollType === 'advantage'
+              ? Math.max(roll1, roll2)
+              : Math.min(roll1, roll2);
+
+          const modifier = isModifierBoxVisible
+            ? parseInt(window.pixelsModifier) || 0
+            : 0;
+          const result = usedValue + modifier;
+
+          const rollLabel =
+            rollType === 'advantage' ? 'Advantage' : 'Disadvantage';
+          const usedArrow = rollType === 'advantage' ? '&#9650;' : '&#9660;';
+
+          let formula = isModifierBoxVisible
+            ? `&{template:default} {{name=#modifier_name (#modifier_sign) - ${rollLabel}}} {{Roll 1=[[#roll1]]}} {{Roll 2=[[#roll2]]}} {{${usedArrow} Used=[[#used_value]]}} {{Result=[[#used_value + #modifier]]}}`
+            : `&{template:default} {{name=Pixel Roll - ${rollLabel}}} {{Roll 1=[[#roll1]]}} {{Roll 2=[[#roll2]]}} {{${usedArrow} Used=[[#used_value]]}} {{Result=[[#result]]}}`;
+
+          // Critical/fumble on the used value
+          if (usedValue === 20 && isModifierBoxVisible) {
+            formula = formula.replace(
+              '{{Roll 1',
+              '{{&#128293; <span style="color: #ff4444; font-size: 20px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.5);">CRITICAL!</span> &#128293;}} {{Roll 1'
+            );
+          }
+          if (usedValue === 1 && isModifierBoxVisible) {
+            formula = formula.replace(
+              '{{Roll 1',
+              '{{&#128128; <span style="color: #888888; font-size: 16px; font-style: italic; opacity: 0.7;">FUMBLE!</span> &#128128;}} {{Roll 1'
+            );
+          }
+
+          const message = formula
+            .replaceAll('#modifier_name', window.pixelsModifierName)
+            .replaceAll('#modifier_sign', formatModifierSign(modifier))
+            .replaceAll('#roll1', roll1.toString())
+            .replaceAll('#roll2', roll2.toString())
+            .replaceAll('#used_value', usedValue.toString())
+            .replaceAll('#modifier', modifier.toString())
+            .replaceAll('#result', result.toString());
+
+          message.split('\\n').forEach(s => postChatMessage(s));
+
+          sendTextToExtension(
+            `${_name}: ${rollLabel} ${roll1} vs ${roll2} → used ${usedValue} + ${modifier} = ${result}`
+          );
+        }
+      } else {
+        // ── NORMAL single roll (original logic) ──
+        const txt = `${_name}: face up = ${diceValue}`;
+
+        const modifier = isModifierBoxVisible
+          ? parseInt(window.pixelsModifier) || 0
+          : 0;
+        const result = diceValue + modifier;
+
+        let formula = isModifierBoxVisible
+          ? pixelsFormulaWithModifier
+          : pixelsFormulaSimple;
+
+        // Add critical hit message if face value is 20
+        if (diceValue === 20 && isModifierBoxVisible) {
+          formula = formula.replace(
+            '{{Pixel=#face_value}}',
+            '{{&#128293; <span style="color: #ff4444; font-size: 20px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.5);">CRITICAL!</span> &#128293;}} {{Pixel=#face_value}}'
+          );
+        }
+
+        // Add fumble message if face value is 1
+        if (diceValue === 1 && isModifierBoxVisible) {
+          formula = formula.replace(
+            '{{Pixel=#face_value}}',
+            '{{&#128128; <span style="color: #888888; font-size: 16px; font-style: italic; opacity: 0.7;">FUMBLE!</span> &#128128;}} {{Pixel=#face_value}}'
+          );
+        }
+
+        const message = formula
+          .replaceAll('#modifier_name', window.pixelsModifierName)
+          .replaceAll('#modifier_sign', formatModifierSign(modifier))
+          .replaceAll('#face_value', diceValue.toString())
+          .replaceAll('#pixel_name', _name)
+          .replaceAll('#modifier', modifier.toString())
+          .replaceAll('#result', result.toString());
+
+        message.split('\\n').forEach(s => postChatMessage(s));
+
+        sendTextToExtension(txt);
       }
-
-      // Add fumble message if face value is 1
-      if (diceValue === 1 && isModifierBoxVisible) {
-        formula = formula.replace(
-          '{{Pixel=#face_value}}',
-          '{{&#128128; <span style="color: #888888; font-size: 16px; font-style: italic; opacity: 0.7;">FUMBLE!</span> &#128128;}} {{Pixel=#face_value}}'
-        );
-      }
-
-      const message = formula
-        .replaceAll('#modifier_name', window.pixelsModifierName)
-        .replaceAll('#modifier_sign', formatModifierSign(modifier))
-        .replaceAll('#face_value', diceValue.toString())
-        .replaceAll('#pixel_name', _name)
-        .replaceAll('#modifier', modifier.toString())
-        .replaceAll('#result', result.toString());
-
-      message.split('\\n').forEach(s => postChatMessage(s));
-
-      sendTextToExtension(txt);
     }
   };
 

--- a/src/content/roll20.js
+++ b/src/content/roll20.js
@@ -23,6 +23,8 @@ if (typeof window.roll20PixelsLoaded === 'undefined') {
   // Global modifier variables (accessed by modifierBox.js)
   window.pixelsModifier = '0';
   window.pixelsModifierName = 'Modifier 1';
+  // Roll type: 'normal' | 'advantage' | 'disadvantage'
+  window.pixelsRollType = 'normal';
 
   // Initialize modules and set up message handling
   function initializeExtension() {

--- a/tests/jest/components/modifierBox/advantageControls.test.js
+++ b/tests/jest/components/modifierBox/advantageControls.test.js
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const uiControlsModule = require('../../../../src/components/modifierBox/uiControls.js');
+
+const setupAdvantageControls = uiControlsModule.setupAdvantageControls;
+
+function createMockModifierBox() {
+  const box = document.createElement('div');
+  box.id = 'pixels-modifier-box';
+  box.innerHTML = `
+    <div class="pixels-advantage-footer">
+      <span class="pixels-advantage-label">Roll:</span>
+      <div class="pixels-advantage-buttons">
+        <button class="advantage-btn active" data-type="normal">Normal</button>
+        <button class="advantage-btn" data-type="advantage">Adv</button>
+        <button class="advantage-btn" data-type="disadvantage">Dis</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(box);
+  return box;
+}
+
+describe('Advantage Controls', () => {
+  beforeEach(() => {
+    resetMocks();
+    localStorage.clear();
+    window.pixelsRollType = 'normal';
+  });
+
+  describe('Initialization', () => {
+    test('defaults to normal when localStorage is empty', () => {
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      expect(window.pixelsRollType).toBe('normal');
+      const normalBtn = box.querySelector('[data-type="normal"]');
+      expect(normalBtn.classList.contains('active')).toBe(true);
+    });
+
+    test('restores saved roll type from localStorage', () => {
+      localStorage.setItem('pixels_roll_type', 'advantage');
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      expect(window.pixelsRollType).toBe('advantage');
+      const advBtn = box.querySelector('[data-type="advantage"]');
+      expect(advBtn.classList.contains('active')).toBe(true);
+      const normalBtn = box.querySelector('[data-type="normal"]');
+      expect(normalBtn.classList.contains('active')).toBe(false);
+    });
+
+    test('restores disadvantage from localStorage', () => {
+      localStorage.setItem('pixels_roll_type', 'disadvantage');
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      expect(window.pixelsRollType).toBe('disadvantage');
+      const disBtn = box.querySelector('[data-type="disadvantage"]');
+      expect(disBtn.classList.contains('active')).toBe(true);
+    });
+
+    test('does nothing if modifierBox is null', () => {
+      expect(() => setupAdvantageControls(null)).not.toThrow();
+    });
+
+    test('does nothing if no advantage buttons are present', () => {
+      const box = document.createElement('div');
+      expect(() => setupAdvantageControls(box)).not.toThrow();
+    });
+  });
+
+  describe('Button clicks', () => {
+    test('clicking Adv sets pixelsRollType to advantage', () => {
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      const advBtn = box.querySelector('[data-type="advantage"]');
+      advBtn.click();
+
+      expect(window.pixelsRollType).toBe('advantage');
+    });
+
+    test('clicking Adv persists to localStorage', () => {
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      const advBtn = box.querySelector('[data-type="advantage"]');
+      advBtn.click();
+
+      expect(localStorage.getItem('pixels_roll_type')).toBe('advantage');
+    });
+
+    test('clicking Adv adds active class to Adv and removes from others', () => {
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      const advBtn = box.querySelector('[data-type="advantage"]');
+      const normalBtn = box.querySelector('[data-type="normal"]');
+      const disBtn = box.querySelector('[data-type="disadvantage"]');
+      advBtn.click();
+
+      expect(advBtn.classList.contains('active')).toBe(true);
+      expect(normalBtn.classList.contains('active')).toBe(false);
+      expect(disBtn.classList.contains('active')).toBe(false);
+    });
+
+    test('clicking Dis sets pixelsRollType to disadvantage', () => {
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      box.querySelector('[data-type="disadvantage"]').click();
+
+      expect(window.pixelsRollType).toBe('disadvantage');
+      expect(localStorage.getItem('pixels_roll_type')).toBe('disadvantage');
+    });
+
+    test('clicking Normal after Adv resets to normal', () => {
+      localStorage.setItem('pixels_roll_type', 'advantage');
+      const box = createMockModifierBox();
+      setupAdvantageControls(box);
+
+      box.querySelector('[data-type="normal"]').click();
+
+      expect(window.pixelsRollType).toBe('normal');
+      expect(localStorage.getItem('pixels_roll_type')).toBe('normal');
+      const normalBtn = box.querySelector('[data-type="normal"]');
+      expect(normalBtn.classList.contains('active')).toBe(true);
+    });
+  });
+});

--- a/tests/jest/pixelsBluetoothAdvantage.test.js
+++ b/tests/jest/pixelsBluetoothAdvantage.test.js
@@ -1,0 +1,262 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Tests for the advantage/disadvantage two-roll logic in PixelsBluetooth.js
+ *
+ * Note: postChatMessage / sendTextToExtension are captured as module-level
+ * constants when PixelsBluetooth.js loads, so we must set window globals
+ * before each require() call and use jest.resetModules() to get a fresh copy.
+ */
+
+// Helper: build a BLE notification DataView for a face event
+// byte 0 = message type (3 = face event), byte 1 = ev, byte 2 = face (0-indexed)
+function makeFaceEvent(ev, face) {
+  const buffer = new ArrayBuffer(3);
+  const view = new DataView(buffer);
+  view.setUint8(0, 3);
+  view.setUint8(1, ev);
+  view.setUint8(2, face);
+  return { target: { value: view } };
+}
+
+// Simulate a full roll: move die (ev=2) then settle (ev=1)
+function simulateRoll(pixel, face) {
+  pixel.handleNotifications(makeFaceEvent(2, 0)); // die moved
+  pixel.handleNotifications(makeFaceEvent(1, face)); // die settled
+}
+
+describe('PixelsBluetooth — advantage/disadvantage roll logic', () => {
+  let createPixel;
+  let mockPostChat;
+  let mockSendText;
+  let mockServer;
+  let mockDevice;
+
+  beforeEach(() => {
+    resetMocks();
+    jest.useFakeTimers();
+    jest.resetModules();
+
+    // Set up mocks on window BEFORE requiring the module so the
+    // module-level const captures pick them up.
+    mockPostChat = jest.fn();
+    mockSendText = jest.fn();
+    window.postChatMessage = mockPostChat;
+    window.sendTextToExtension = mockSendText;
+    window.sendStatusToExtension = jest.fn();
+    window.log = jest.fn();
+
+    // Modifier box visible with a modifier set
+    window.ModifierBox = {
+      isVisible: () => true,
+      syncGlobalVars: jest.fn(),
+    };
+    window.pixelsModifier = '3';
+    window.pixelsModifierName = 'Str Attack';
+    window.pixelsRollType = 'normal';
+
+    // Require the module fresh after globals are set
+    ({ createPixel } = require('../../src/content/modules/PixelsBluetooth.js'));
+
+    mockDevice = { id: 'device-1', gatt: { connected: true } };
+    mockServer = { connected: true, disconnect: jest.fn() };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // ── Normal roll (unchanged behaviour) ──────────────────────────────────────
+
+  describe('Normal mode', () => {
+    test('posts immediately on a single roll', () => {
+      window.pixelsRollType = 'normal';
+      const pixel = createPixel('TestDie', mockServer, mockDevice);
+      simulateRoll(pixel, 14); // face 14 = value 15
+
+      expect(mockPostChat).toHaveBeenCalledTimes(1);
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('15');
+      expect(msg).not.toContain('Advantage');
+      expect(msg).not.toContain('Disadvantage');
+    });
+  });
+
+  // ── Advantage ──────────────────────────────────────────────────────────────
+
+  describe('Advantage mode', () => {
+    let pixel;
+    beforeEach(() => {
+      window.pixelsRollType = 'advantage';
+      pixel = createPixel('TestDie', mockServer, mockDevice);
+    });
+
+    test('does not post to Roll20 on the first roll', () => {
+      simulateRoll(pixel, 14); // roll 1: value 15
+      expect(mockPostChat).not.toHaveBeenCalled();
+    });
+
+    test('sends popup status after first roll', () => {
+      simulateRoll(pixel, 14);
+      expect(mockSendText).toHaveBeenCalledWith(
+        expect.stringContaining('Roll 1 = 15')
+      );
+    });
+
+    test('posts to Roll20 on the second roll using the higher value', () => {
+      simulateRoll(pixel, 14); // roll 1: value 15
+      simulateRoll(pixel, 11); // roll 2: value 12 → lower
+      expect(mockPostChat).toHaveBeenCalledTimes(1);
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('Advantage');
+      expect(msg).toContain('Roll 1=[[15]]');
+      expect(msg).toContain('Roll 2=[[12]]');
+      expect(msg).toContain('Used=[[15]]'); // higher value used
+      expect(msg).toContain('15 + 3'); // modifier applied
+    });
+
+    test('uses higher value when roll 2 is greater', () => {
+      simulateRoll(pixel, 11); // roll 1: value 12
+      simulateRoll(pixel, 14); // roll 2: value 15 → higher
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('Used=[[15]]');
+    });
+
+    test('includes modifier name in formula', () => {
+      simulateRoll(pixel, 14);
+      simulateRoll(pixel, 11);
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('Str Attack');
+    });
+
+    test('shows CRITICAL decoration when used value is 20', () => {
+      simulateRoll(pixel, 19); // value 20
+      simulateRoll(pixel, 9); // value 10
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('CRITICAL');
+    });
+
+    test('does not show FUMBLE when lower die is 1 but advantage uses higher', () => {
+      simulateRoll(pixel, 0); // value 1
+      simulateRoll(pixel, 4); // value 5 → advantage uses 5
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).not.toContain('FUMBLE');
+    });
+
+    test('resets state after second roll so next roll starts fresh', () => {
+      simulateRoll(pixel, 14);
+      simulateRoll(pixel, 11);
+      mockPostChat.mockClear();
+      mockSendText.mockClear();
+
+      // Next single roll should be a new roll 1, not post immediately
+      simulateRoll(pixel, 7);
+      expect(mockPostChat).not.toHaveBeenCalled();
+      expect(mockSendText).toHaveBeenCalledWith(
+        expect.stringContaining('Roll 1 = 8')
+      );
+    });
+  });
+
+  // ── Disadvantage ──────────────────────────────────────────────────────────
+
+  describe('Disadvantage mode', () => {
+    let pixel;
+    beforeEach(() => {
+      window.pixelsRollType = 'disadvantage';
+      pixel = createPixel('TestDie', mockServer, mockDevice);
+    });
+
+    test('posts to Roll20 on the second roll using the lower value', () => {
+      simulateRoll(pixel, 14); // value 15
+      simulateRoll(pixel, 11); // value 12 → lower
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('Disadvantage');
+      expect(msg).toContain('Roll 1=[[15]]');
+      expect(msg).toContain('Roll 2=[[12]]');
+      expect(msg).toContain('Used=[[12]]'); // lower value used
+      expect(msg).toContain('12 + 3');
+    });
+
+    test('shows FUMBLE decoration when used value is 1', () => {
+      simulateRoll(pixel, 4); // value 5
+      simulateRoll(pixel, 0); // value 1 → lower, used
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('FUMBLE');
+    });
+
+    test('shows CRITICAL decoration when both dice are 20', () => {
+      simulateRoll(pixel, 19); // value 20
+      simulateRoll(pixel, 19); // value 20 → lower is still 20
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('CRITICAL');
+    });
+  });
+
+  // ── Timeout ────────────────────────────────────────────────────────────────
+
+  describe('Timeout handling', () => {
+    let pixel;
+    beforeEach(() => {
+      window.pixelsRollType = 'advantage';
+      pixel = createPixel('TestDie', mockServer, mockDevice);
+    });
+
+    test('cancels pending roll after 15 seconds with no second roll', () => {
+      simulateRoll(pixel, 14);
+      expect(mockPostChat).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(15000);
+
+      // Nothing posted to Roll20
+      expect(mockPostChat).not.toHaveBeenCalled();
+      // Cancellation message sent to popup
+      expect(mockSendText).toHaveBeenCalledWith(
+        expect.stringContaining('Timed out')
+      );
+    });
+
+    test('after timeout, next roll is treated as roll 1 again', () => {
+      simulateRoll(pixel, 14);
+      jest.advanceTimersByTime(15000);
+      mockSendText.mockClear();
+
+      simulateRoll(pixel, 9);
+      expect(mockPostChat).not.toHaveBeenCalled();
+      expect(mockSendText).toHaveBeenCalledWith(
+        expect.stringContaining('Roll 1 = 10')
+      );
+    });
+
+    test('second roll before timeout cancels the timer cleanly', () => {
+      simulateRoll(pixel, 14);
+      simulateRoll(pixel, 11);
+
+      // Advancing time should not trigger any additional messages
+      const callCount = mockSendText.mock.calls.length;
+      jest.advanceTimersByTime(15000);
+      expect(mockSendText.mock.calls.length).toBe(callCount);
+    });
+  });
+
+  // ── Modifier box hidden ───────────────────────────────────────────────────
+
+  describe('Modifier box hidden', () => {
+    let pixel;
+    beforeEach(() => {
+      window.ModifierBox = { isVisible: () => false };
+      window.pixelsRollType = 'advantage';
+      pixel = createPixel('TestDie', mockServer, mockDevice);
+    });
+
+    test('posts result without modifier when modifier box is hidden', () => {
+      simulateRoll(pixel, 14);
+      simulateRoll(pixel, 11);
+      const msg = mockPostChat.mock.calls[0][0];
+      expect(msg).toContain('Pixel Roll - Advantage');
+      expect(msg).toContain('Used=[[15]]');
+      // No modifier name in simple formula
+      expect(msg).not.toContain('Str Attack');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a **Normal / Adv / Dis** toggle footer to the modifier box so players can select their roll mode before throwing the die
- When **Advantage** or **Disadvantage** is active, the extension buffers the first physical roll and waits for a second roll of the same die, then posts a combined result to Roll20 chat showing both dice and the value used
- A 15-second timeout silently cancels a pending roll (popup notification only — nothing posted to Roll20 chat)
- Roll mode selection persists across page refreshes via `localStorage`
- Fully compatible with existing modifier rows, light/dark theme switching, and the minimize state

## How it works in Roll20 chat

**Advantage** (roll 15, then 12, modifier +3):
```
{{name=Str Attack (+3) - Advantage}} {{Roll 1=[[15]]}} {{Roll 2=[[12]]}} {{▲ Used=[[15]]}} {{Result=[[15 + 3]]}}
```

**Disadvantage** (roll 15, then 12, modifier +3):
```
{{name=Str Attack (+3) - Disadvantage}} {{Roll 1=[[15]]}} {{Roll 2=[[12]]}} {{▼ Used=[[12]]}} {{Result=[[12 + 3]]}}
```

Critical (used = 20) and Fumble (used = 1) decorations are applied just like normal rolls.

## Files changed

| File | Change |
|---|---|
| `src/content/roll20.js` | Initialise `window.pixelsRollType` global |
| `src/components/modifierBox/modifierBox.html` | Add advantage footer HTML |
| `src/components/modifierBox/modifierBox.js` | Add footer to inline fallback |
| `src/components/modifierBox/styles/modifierBox.css` | Dark-theme button styles |
| `src/components/modifierBox/styles/lightTheme.css` | Light-theme overrides |
| `src/components/modifierBox/uiControls.js` | `setupAdvantageControls()` |
| `src/components/modifierBox/componentInitializer.js` | Wire up advantage controls |
| `src/content/modules/PixelsBluetooth.js` | Per-die two-roll buffering logic |

## Test plan

- [x] 26 new unit tests added (advantage controls UI + Bluetooth roll logic)
- [x] All 214 tests pass
- [x] Webpack build clean
- [ ] Manual: load unpacked extension, connect Pixel die, verify Normal/Adv/Dis buttons appear
- [ ] Manual: roll in Advantage mode — first roll shows popup status, second roll posts to Roll20
- [ ] Manual: roll in Disadvantage mode — lower value used in result
- [ ] Manual: wait 15s after roll 1 — cancellation message in popup, nothing in Roll20 chat
- [ ] Manual: verify light theme styling and minimize/restore behaviour
- [ ] Manual: refresh page — saved roll type is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)