### PR TITLE
Add popout profiles and persistent minimize state

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,9 @@ module.exports = [
         fetch: 'readonly',
         getComputedStyle: 'readonly',
         MutationObserver: 'readonly',
+        Blob: 'readonly',
+        URL: 'readonly',
+        FileReader: 'readonly',
 
         // Extension-specific globals
         postChatMessage: 'readonly',

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
       ],
       "js": [
         "src/utils/modifierSettings.js",
+        "src/utils/profileStorage.js",
         "src/utils/themeDetector.js",
         "src/utils/cssLoader.js",
         "src/utils/htmlLoader.js",

--- a/src/components/modifierBox/componentInitializer.js
+++ b/src/components/modifierBox/componentInitializer.js
@@ -17,7 +17,11 @@ import {
   updateSelectedModifier as updateSelectedModifierFromRowManager,
   loadModifierRows,
 } from './rowManager.js';
-import { setupMinimizeControls, setupClearAllControls } from './uiControls.js';
+import {
+  setupMinimizeControls,
+  setupClearAllControls,
+  restoreMinimizedState,
+} from './uiControls.js';
 
 export function setupModifierBoxComponents(modifierBox, clearAllCallback) {
   if (!modifierBox) {
@@ -144,6 +148,10 @@ function setupUIControls(modifierBox, clearAllCallback) {
   if (clearAllCallback) {
     setupClearAllControls(modifierBox, clearAllCallback);
   }
+
+  // Restore the persisted minimized/full-size state (independent of profiles).
+  // Fire-and-forget: the storage read is async and applies once it resolves.
+  restoreMinimizedState(modifierBox);
 }
 
 function setupThemeManagement(modifierBox) {

--- a/src/components/modifierBox/rowManager.js
+++ b/src/components/modifierBox/rowManager.js
@@ -49,8 +49,11 @@ window.ModifierBoxRowManager = {
   updateSelectedModifier: updateSelectedModifier,
   clearModifierState: clearModifierState,
   reindexRows: reindexRows,
+  serializeRows: serializeRows,
+  applyRows: applyRows,
   saveModifierRows: saveModifierRows,
   loadModifierRows: loadModifierRows,
+  applyProfileRows: applyProfileRows,
   clearStoredModifierRows: clearStoredModifierRows,
   resetAllRows: resetAllRows,
   getRowCounter: () => rowCounter,
@@ -341,6 +344,39 @@ function updateSelectedModifier(modifierBox) {
   }
 }
 
+// Pure serialization of the current rows in their DOM order (preserves
+// drag-and-drop order). Returns { rows: [{ name, value, originalIndex }],
+// selectedIndex }. Shared by localStorage persistence and profile saving.
+function serializeRows(modifierBox) {
+  const rowsData = [];
+  let selectedIndex = -1;
+
+  if (!modifierBox) {
+    return { rows: rowsData, selectedIndex };
+  }
+
+  const rows = modifierBox.querySelectorAll('.modifier-row');
+  rows.forEach((row, domIndex) => {
+    const radio = row.querySelector('.modifier-radio');
+    const nameInput = row.querySelector('.modifier-name');
+    const valueInput = row.querySelector('.modifier-value');
+
+    if (nameInput && valueInput) {
+      rowsData.push({
+        name: nameInput.value || 'Modifier',
+        value: valueInput.value || '0',
+        originalIndex: radio ? radio.value : domIndex.toString(), // Store original index for reference
+      });
+
+      if (radio && radio.checked) {
+        selectedIndex = domIndex; // Use DOM index for selection
+      }
+    }
+  });
+
+  return { rows: rowsData, selectedIndex };
+}
+
 // Function to save all modifier rows to localStorage
 function saveModifierRows(modifierBox) {
   if (!modifierBox) {
@@ -348,32 +384,11 @@ function saveModifierRows(modifierBox) {
   }
 
   try {
-    const rows = modifierBox.querySelectorAll('.modifier-row');
-    const rowsData = [];
-    let selectedIndex = -1;
-
-    // Capture rows in their current DOM order (preserves drag-and-drop order)
-    rows.forEach((row, domIndex) => {
-      const radio = row.querySelector('.modifier-radio');
-      const nameInput = row.querySelector('.modifier-name');
-      const valueInput = row.querySelector('.modifier-value');
-
-      if (nameInput && valueInput) {
-        rowsData.push({
-          name: nameInput.value || 'Modifier',
-          value: valueInput.value || '0',
-          originalIndex: radio ? radio.value : domIndex.toString(), // Store original index for reference
-        });
-
-        if (radio && radio.checked) {
-          selectedIndex = domIndex; // Use DOM index for selection
-        }
-      }
-    });
+    const { rows, selectedIndex } = serializeRows(modifierBox);
 
     const modifierState = {
-      rows: rowsData,
-      selectedIndex: selectedIndex,
+      rows,
+      selectedIndex,
       rowCounter: rowCounter,
       lastUpdated: Date.now(),
     };
@@ -382,6 +397,73 @@ function saveModifierRows(modifierBox) {
   } catch (error) {
     console.error('Error saving modifier rows:', error);
   }
+}
+
+// Rebuild the modifier rows in the DOM from serialized data
+// ({ rows: [{ name, value }], selectedIndex }). Shared by localStorage loading
+// and profile applying. Returns true on success.
+function applyRows(modifierBox, data, updateSelectedModifierCallback) {
+  if (!modifierBox || !data || !Array.isArray(data.rows)) {
+    return false;
+  }
+
+  const content = modifierBox.querySelector('.pixels-content');
+  if (!content) {
+    return false;
+  }
+
+  // Ensure the row counter stays ahead of the rebuilt indices so future rows
+  // get unique values (rows are reindexed 0..n-1 on rebuild).
+  rowCounter = Math.max(rowCounter, data.rows.length);
+
+  // Remove all existing modifier rows
+  const existingRows = content.querySelectorAll('.modifier-row');
+  existingRows.forEach(row => row.remove());
+
+  // Recreate rows from the supplied data
+  data.rows.forEach((rowData, index) => {
+    const newRow = document.createElement('div');
+    newRow.className = 'modifier-row';
+    newRow.innerHTML = `
+          <div class="drag-handle" title="Drag to reorder">⋮⋮</div>
+          <input type="radio" name="modifier-select" value="${index}" class="modifier-radio" id="mod-${index}">
+          <input type="text" class="modifier-name" placeholder="Modifier" value="${rowData.name}" data-index="${index}">
+          <input type="number" class="modifier-value" value="${rowData.value}" min="-99" max="99" data-index="${index}">
+          <button class="remove-row-btn" type="button">×</button>
+        `;
+
+    content.appendChild(newRow);
+  });
+
+  // Restore selected row
+  if (data.selectedIndex >= 0 && data.selectedIndex < data.rows.length) {
+    const selectedRadio = modifierBox.querySelector(
+      `input[name="modifier-select"][value="${data.selectedIndex}"]`
+    );
+    if (selectedRadio) {
+      selectedRadio.checked = true;
+    }
+  }
+
+  // Update event listeners for all rows
+  updateEventListeners(modifierBox, updateSelectedModifierCallback);
+
+  // Update the selected modifier to sync global variables
+  if (updateSelectedModifierCallback) {
+    updateSelectedModifierCallback();
+  }
+
+  // Force theme updates on the restored elements
+  if (
+    window.ModifierBoxThemeManager &&
+    window.ModifierBoxThemeManager.forceElementUpdates
+  ) {
+    window.ModifierBoxThemeManager.forceElementUpdates(modifierBox);
+  } else if (forceElementUpdates) {
+    forceElementUpdates(modifierBox);
+  }
+
+  return true;
 }
 
 // Function to load modifier rows from localStorage
@@ -406,67 +488,33 @@ function loadModifierRows(modifierBox, updateSelectedModifierCallback) {
       rowCounter = modifierState.rowCounter;
     }
 
-    // Clear existing rows
-    const content = modifierBox.querySelector('.pixels-content');
-    if (!content) {
-      return false;
-    }
-
-    // Remove all existing modifier rows
-    const existingRows = content.querySelectorAll('.modifier-row');
-    existingRows.forEach(row => row.remove());
-
-    // Recreate rows from stored data
-    modifierState.rows.forEach((rowData, index) => {
-      const newRow = document.createElement('div');
-      newRow.className = 'modifier-row';
-      newRow.innerHTML = `
-          <div class="drag-handle" title="Drag to reorder">⋮⋮</div>
-          <input type="radio" name="modifier-select" value="${index}" class="modifier-radio" id="mod-${index}">
-          <input type="text" class="modifier-name" placeholder="Modifier" value="${rowData.name}" data-index="${index}">
-          <input type="number" class="modifier-value" value="${rowData.value}" min="-99" max="99" data-index="${index}">
-          <button class="remove-row-btn" type="button">×</button>
-        `;
-
-      content.appendChild(newRow);
-    });
-
-    // Restore selected row
-    if (
-      modifierState.selectedIndex >= 0 &&
-      modifierState.selectedIndex < modifierState.rows.length
-    ) {
-      const selectedRadio = modifierBox.querySelector(
-        `input[name="modifier-select"][value="${modifierState.selectedIndex}"]`
-      );
-      if (selectedRadio) {
-        selectedRadio.checked = true;
-      }
-    }
-
-    // Update event listeners for all rows
-    updateEventListeners(modifierBox, updateSelectedModifierCallback);
-
-    // Update the selected modifier to sync global variables
-    if (updateSelectedModifierCallback) {
-      updateSelectedModifierCallback();
-    }
-
-    // Force theme updates on the restored elements
-    if (
-      window.ModifierBoxThemeManager &&
-      window.ModifierBoxThemeManager.forceElementUpdates
-    ) {
-      window.ModifierBoxThemeManager.forceElementUpdates(modifierBox);
-    } else if (forceElementUpdates) {
-      forceElementUpdates(modifierBox);
-    }
-
-    return true;
+    return applyRows(
+      modifierBox,
+      modifierState,
+      updateSelectedModifierCallback
+    );
   } catch (error) {
     console.error('Error loading modifier rows:', error);
     return false;
   }
+}
+
+// Apply a saved profile's rows to the modifier box and persist the result to
+// localStorage so the restored state survives a reload. Returns true on success.
+function applyProfileRows(
+  modifierBox,
+  profile,
+  updateSelectedModifierCallback
+) {
+  const applied = applyRows(
+    modifierBox,
+    profile,
+    updateSelectedModifierCallback
+  );
+  if (applied) {
+    saveModifierRows(modifierBox);
+  }
+  return applied;
 }
 
 // Function to clear stored modifier rows
@@ -535,8 +583,11 @@ export { updateEventListeners };
 export { updateSelectedModifier };
 export { clearModifierState };
 export { reindexRows };
+export { serializeRows };
+export { applyRows };
 export { saveModifierRows };
 export { loadModifierRows };
+export { applyProfileRows };
 export { clearStoredModifierRows };
 export { resetAllRows };
 export const getRowCounter = () => rowCounter;
@@ -556,8 +607,11 @@ export default {
   updateSelectedModifier,
   clearModifierState,
   reindexRows,
+  serializeRows,
+  applyRows,
   saveModifierRows,
   loadModifierRows,
+  applyProfileRows,
   clearStoredModifierRows,
   resetAllRows,
   getRowCounter,
@@ -574,8 +628,11 @@ if (typeof window !== 'undefined') {
     updateSelectedModifier,
     clearModifierState,
     reindexRows,
+    serializeRows,
+    applyRows,
     saveModifierRows,
     loadModifierRows,
+    applyProfileRows,
     clearStoredModifierRows,
     resetAllRows,
     getRowCounter,

--- a/src/components/modifierBox/uiControls.js
+++ b/src/components/modifierBox/uiControls.js
@@ -23,12 +23,68 @@ export function setupMinimizeControls(modifierBox) {
 
     const isCurrentlyMinimized = modifierBox.classList.contains('minimized');
 
-    if (!isCurrentlyMinimized) {
-      minimizeModifierBox(modifierBox, minimizeBtn);
-    } else {
-      restoreModifierBox(modifierBox, minimizeBtn);
-    }
+    // Toggle, then persist the new state so it survives a reload.
+    applyMinimizedState(modifierBox, !isCurrentlyMinimized);
+    persistMinimizedState(!isCurrentlyMinimized);
   });
+}
+
+// Persist the minimized flag (per-device preference) via the storage wrapper.
+function persistMinimizedState(minimized) {
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      window.PixelsProfileStorage &&
+      typeof window.PixelsProfileStorage.setMinimized === 'function'
+    ) {
+      window.PixelsProfileStorage.setMinimized(minimized);
+    }
+  } catch (error) {
+    console.error('Error persisting minimized state:', error);
+  }
+}
+
+// Apply the minimized/restored visual state without persisting. Used both by
+// the toggle handler and by the restore-on-load path in the initializer.
+export function applyMinimizedState(modifierBox, minimized) {
+  if (!modifierBox) {
+    console.error('applyMinimizedState: modifierBox is required');
+    return;
+  }
+
+  const minimizeBtn = modifierBox.querySelector('.pixels-minimize');
+  if (!minimizeBtn) {
+    console.error('Minimize button not found!');
+    return;
+  }
+
+  if (minimized) {
+    minimizeModifierBox(modifierBox, minimizeBtn);
+  } else {
+    restoreModifierBox(modifierBox, minimizeBtn);
+  }
+}
+
+// Read the persisted minimized flag and apply it to the box. Async because the
+// storage wrapper is Promise-based.
+export async function restoreMinimizedState(modifierBox) {
+  if (!modifierBox) {
+    return;
+  }
+  try {
+    if (
+      typeof window !== 'undefined' &&
+      window.PixelsProfileStorage &&
+      typeof window.PixelsProfileStorage.getMinimized === 'function'
+    ) {
+      const minimized = await window.PixelsProfileStorage.getMinimized();
+      if (minimized) {
+        applyMinimizedState(modifierBox, true);
+      }
+    }
+  } catch (error) {
+    console.error('Error restoring minimized state:', error);
+  }
 }
 
 function minimizeModifierBox(modifierBox, minimizeBtn) {
@@ -93,6 +149,8 @@ export function setupClearAllControls(modifierBox, clearAllCallback) {
 const UIControls = {
   setupMinimizeControls,
   setupClearAllControls,
+  applyMinimizedState,
+  restoreMinimizedState,
 };
 
 export default UIControls;

--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -212,6 +212,31 @@ body {
   color: #cccccc;
 }
 
+.active-profile-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #1f3147;
+  border: 1px solid #4a9eff;
+  border-radius: 4px;
+  padding: 6px 8px 6px 10px;
+}
+
+.active-profile-label {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: #cfe3ff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.active-profile-label #activeProfileName {
+  font-weight: bold;
+  color: #ffffff;
+}
+
 .profile-save-row {
   display: flex;
   gap: 8px;
@@ -261,6 +286,10 @@ body {
   padding: 6px 8px 6px 10px;
 }
 
+.profile-item.active {
+  border-color: #4a9eff;
+}
+
 .profile-item-name {
   flex: 1;
   min-width: 0;
@@ -269,6 +298,20 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.profile-item .active-dot {
+  color: #4a9eff;
+  margin-right: 4px;
+}
+
+.profile-io-row {
+  display: flex;
+  gap: 8px;
+}
+
+.profile-io-row .secondary-button {
+  flex: 1;
 }
 
 .profile-item-btn {

--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -197,6 +197,103 @@ body {
   background-color: #3a8eef;
 }
 
+/* Profiles Section */
+.profiles-section {
+  border-top: 1px solid #444444;
+  padding-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-label {
+  font-size: 13px;
+  font-weight: bold;
+  color: #cccccc;
+}
+
+.profile-save-row {
+  display: flex;
+  gap: 8px;
+}
+
+.profile-input {
+  flex: 1;
+  min-width: 0;
+  background-color: #1a1a1a;
+  border: 1px solid #444444;
+  border-radius: 4px;
+  color: #ffffff;
+  font-size: 13px;
+  padding: 8px 10px;
+}
+
+.profile-input::placeholder {
+  color: #777777;
+}
+
+.profile-input:focus {
+  outline: 2px solid #4a9eff;
+  outline-offset: 0;
+}
+
+.profile-save-btn {
+  flex-shrink: 0;
+  padding: 8px 16px;
+}
+
+.profile-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-color: #1a1a1a;
+  border: 1px solid #444444;
+  border-radius: 4px;
+  padding: 6px 8px 6px 10px;
+}
+
+.profile-item-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.profile-item-btn {
+  flex-shrink: 0;
+  background-color: #404040;
+  color: #ffffff;
+  border: 1px solid #555555;
+  border-radius: 4px;
+  padding: 5px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.profile-item-btn:hover {
+  background-color: #4a4a4a;
+  border-color: #666666;
+}
+
+.profile-item-btn.delete:hover {
+  background-color: #5a2a2a;
+  border-color: #f87171;
+  color: #f87171;
+}
+
 /* Status indicators */
 .status-connected {
   color: #4ade80 !important;

--- a/src/components/popup/popup.html
+++ b/src/components/popup/popup.html
@@ -33,6 +33,27 @@
             </button>
           </div>
         </div>
+
+        <!-- Profiles -->
+        <div class="profiles-section">
+          <div class="section-label">Saved Profiles</div>
+          <div class="profile-save-row">
+            <input
+              id="profileName"
+              type="text"
+              class="profile-input"
+              placeholder="Profile name"
+              maxlength="40"
+            />
+            <button id="saveProfile" class="primary-button profile-save-btn">
+              Save
+            </button>
+          </div>
+          <ul id="profileList" class="profile-list"></ul>
+          <div id="profileEmpty" class="text-small text-muted">
+            No saved profiles yet.
+          </div>
+        </div>
       </div>
     </div>
     <!-- <button id="disconnect">Disconnect</button> -->

--- a/src/components/popup/popup.html
+++ b/src/components/popup/popup.html
@@ -37,6 +37,24 @@
         <!-- Profiles -->
         <div class="profiles-section">
           <div class="section-label">Saved Profiles</div>
+
+          <div
+            id="activeProfileBanner"
+            class="active-profile-banner"
+            style="display: none"
+          >
+            <span class="active-profile-label"
+              >Active: <span id="activeProfileName"></span
+            ></span>
+            <button
+              id="updateProfile"
+              class="profile-item-btn"
+              title="Save current popout into the active profile"
+            >
+              Update ↻
+            </button>
+          </div>
+
           <div class="profile-save-row">
             <input
               id="profileName"
@@ -52,6 +70,17 @@
           <ul id="profileList" class="profile-list"></ul>
           <div id="profileEmpty" class="text-small text-muted">
             No saved profiles yet.
+          </div>
+
+          <div class="profile-io-row">
+            <button id="exportProfiles" class="secondary-button">Export</button>
+            <button id="importProfiles" class="secondary-button">Import</button>
+            <input
+              id="importFile"
+              type="file"
+              accept="application/json,.json"
+              style="display: none"
+            />
           </div>
         </div>
       </div>

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -4,6 +4,10 @@ import {
   getProfiles,
   saveProfile,
   deleteProfile,
+  getActiveProfile,
+  setActiveProfile,
+  exportProfiles,
+  importProfiles,
 } from '../../utils/profileStorage.js';
 
 // Simple theme detection and CSS loading
@@ -155,7 +159,7 @@ function sendMessage(data, responseCallback) {
 
 // --- Profiles ---------------------------------------------------------------
 
-// Render the list of saved profiles with Load/Delete controls.
+// Render the saved-profile list, the active-profile banner, and active marker.
 async function renderProfiles() {
   const list = document.getElementById('profileList');
   const empty = document.getElementById('profileEmpty');
@@ -164,11 +168,19 @@ async function renderProfiles() {
   }
 
   let profiles = {};
+  let active = null;
   try {
-    profiles = await getProfiles();
+    [profiles, active] = await Promise.all([getProfiles(), getActiveProfile()]);
   } catch {
     profiles = {};
+    active = null;
   }
+
+  // Active profile is only meaningful while it still exists.
+  if (active && !(active in profiles)) {
+    active = null;
+  }
+  renderActiveBanner(active);
 
   const names = Object.keys(profiles).sort((a, b) => a.localeCompare(b));
   list.innerHTML = '';
@@ -185,12 +197,18 @@ async function renderProfiles() {
 
   names.forEach(name => {
     const li = document.createElement('li');
-    li.className = 'profile-item';
+    li.className = name === active ? 'profile-item active' : 'profile-item';
 
     const label = document.createElement('span');
     label.className = 'profile-item-name';
-    label.textContent = name;
     label.title = name;
+    if (name === active) {
+      const dot = document.createElement('span');
+      dot.className = 'active-dot';
+      dot.textContent = '●';
+      label.appendChild(dot);
+    }
+    label.appendChild(document.createTextNode(name));
 
     const loadBtn = document.createElement('button');
     loadBtn.className = 'profile-item-btn load';
@@ -209,7 +227,33 @@ async function renderProfiles() {
   });
 }
 
-// Save the current popout's rows as a named profile.
+// Show/hide the "Active: <name>" banner with its Update button.
+function renderActiveBanner(active) {
+  const banner = document.getElementById('activeProfileBanner');
+  const nameEl = document.getElementById('activeProfileName');
+  if (!banner || !nameEl) {
+    return;
+  }
+  if (active) {
+    nameEl.textContent = active;
+    banner.style.display = 'flex';
+  } else {
+    banner.style.display = 'none';
+  }
+}
+
+// Fetch the current popout rows from the active Roll20 tab, then run `next`.
+function withCurrentRows(next) {
+  sendMessage({ action: 'getCurrentRows' }, rows => {
+    if (chrome.runtime.lastError || !rows || !Array.isArray(rows.rows)) {
+      showText('Open Roll20 to read the current popout.');
+      return;
+    }
+    next(rows);
+  });
+}
+
+// Save the current popout's rows as a named profile (confirm before overwrite).
 function saveCurrentProfile() {
   const input = document.getElementById('profileName');
   const name = input ? input.value.trim() : '';
@@ -218,24 +262,47 @@ function saveCurrentProfile() {
     return;
   }
 
-  sendMessage({ action: 'getCurrentRows' }, rows => {
-    if (chrome.runtime.lastError || !rows || !Array.isArray(rows.rows)) {
-      showText('Open Roll20 to save the current popout.');
+  getProfiles().then(profiles => {
+    if (
+      name in profiles &&
+      !window.confirm(`Profile "${name}" already exists. Overwrite it?`)
+    ) {
       return;
     }
-    saveProfile(name, rows)
-      .then(() => {
-        if (input) {
-          input.value = '';
-        }
-        showText(`Saved profile "${name}".`);
-        renderProfiles();
-      })
-      .catch(() => showText('Failed to save profile.'));
+    withCurrentRows(rows => {
+      saveProfile(name, rows)
+        .then(() => setActiveProfile(name))
+        .then(() => {
+          if (input) {
+            input.value = '';
+          }
+          showText(`Saved profile "${name}".`);
+          renderProfiles();
+        })
+        .catch(() => showText('Failed to save profile.'));
+    });
   });
 }
 
-// Apply a saved profile to the popout in the active Roll20 tab.
+// Overwrite the active profile with the current popout state.
+function updateActiveProfile() {
+  getActiveProfile().then(active => {
+    if (!active) {
+      showText('No active profile to update.');
+      return;
+    }
+    withCurrentRows(rows => {
+      saveProfile(active, rows)
+        .then(() => {
+          showText(`Updated profile "${active}".`);
+          renderProfiles();
+        })
+        .catch(() => showText('Failed to update profile.'));
+    });
+  });
+}
+
+// Apply a saved profile to the popout and mark it active.
 function loadProfile(name) {
   getProfiles().then(profiles => {
     const profile = profiles[name];
@@ -249,19 +316,80 @@ function loadProfile(name) {
         showText('Open Roll20 to load a profile.');
         return;
       }
-      showText(`Loaded profile "${name}".`);
+      setActiveProfile(name).then(() => {
+        showText(`Loaded profile "${name}".`);
+        renderProfiles();
+      });
     });
   });
 }
 
-// Delete a saved profile.
+// Delete a saved profile; clear active if it was the one removed.
 function removeProfile(name) {
-  deleteProfile(name)
+  Promise.all([deleteProfile(name), getActiveProfile()])
+    .then(([, active]) => {
+      if (active === name) {
+        return setActiveProfile('');
+      }
+      return undefined;
+    })
     .then(() => {
       showText(`Deleted profile "${name}".`);
       renderProfiles();
     })
     .catch(() => showText('Failed to delete profile.'));
+}
+
+// Export all profiles to a downloaded JSON file.
+function exportProfilesToFile() {
+  exportProfiles()
+    .then(bundle => {
+      if (!bundle.profiles || Object.keys(bundle.profiles).length === 0) {
+        showText('No profiles to export.');
+        return;
+      }
+      const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const stamp = new Date().toISOString().slice(0, 10);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `pixels-roll20-profiles-${stamp}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      showText('Exported profiles.');
+    })
+    .catch(() => showText('Failed to export profiles.'));
+}
+
+// Import profiles from a chosen JSON file, merging (keep-both on name clash).
+function importProfilesFromFile(file) {
+  if (!file) {
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    let bundle;
+    try {
+      bundle = JSON.parse(reader.result);
+    } catch {
+      showText('Could not read that file (invalid JSON).');
+      return;
+    }
+    importProfiles(bundle)
+      .then(result => {
+        if (result.error || result.imported === 0) {
+          showText('No profiles found to import.');
+          return;
+        }
+        showText(`Imported ${result.imported} profile(s).`);
+        renderProfiles();
+      })
+      .catch(() => showText('Failed to import profiles.'));
+  };
+  reader.onerror = () => showText('Could not read that file.');
+  reader.readAsText(file);
 }
 
 // Listen on messages from injected JS
@@ -318,6 +446,23 @@ document.addEventListener('DOMContentLoaded', () => {
       if (e.key === 'Enter') {
         saveCurrentProfile();
       }
+    });
+  }
+  const updateProfileBtn = document.getElementById('updateProfile');
+  if (updateProfileBtn) {
+    updateProfileBtn.onclick = updateActiveProfile;
+  }
+  const exportBtn = document.getElementById('exportProfiles');
+  if (exportBtn) {
+    exportBtn.onclick = exportProfilesToFile;
+  }
+  const importBtn = document.getElementById('importProfiles');
+  const importFile = document.getElementById('importFile');
+  if (importBtn && importFile) {
+    importBtn.onclick = () => importFile.click();
+    importFile.addEventListener('change', () => {
+      importProfilesFromFile(importFile.files[0]);
+      importFile.value = ''; // allow re-importing the same file
     });
   }
   renderProfiles();

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -1,5 +1,11 @@
 'use strict';
 
+import {
+  getProfiles,
+  saveProfile,
+  deleteProfile,
+} from '../../utils/profileStorage.js';
+
 // Simple theme detection and CSS loading
 function detectAndApplyTheme() {
   if (typeof chrome !== 'undefined' && chrome.tabs) {
@@ -147,6 +153,117 @@ function sendMessage(data, responseCallback) {
   });
 }
 
+// --- Profiles ---------------------------------------------------------------
+
+// Render the list of saved profiles with Load/Delete controls.
+async function renderProfiles() {
+  const list = document.getElementById('profileList');
+  const empty = document.getElementById('profileEmpty');
+  if (!list) {
+    return;
+  }
+
+  let profiles = {};
+  try {
+    profiles = await getProfiles();
+  } catch {
+    profiles = {};
+  }
+
+  const names = Object.keys(profiles).sort((a, b) => a.localeCompare(b));
+  list.innerHTML = '';
+
+  if (names.length === 0) {
+    if (empty) {
+      empty.style.display = 'block';
+    }
+    return;
+  }
+  if (empty) {
+    empty.style.display = 'none';
+  }
+
+  names.forEach(name => {
+    const li = document.createElement('li');
+    li.className = 'profile-item';
+
+    const label = document.createElement('span');
+    label.className = 'profile-item-name';
+    label.textContent = name;
+    label.title = name;
+
+    const loadBtn = document.createElement('button');
+    loadBtn.className = 'profile-item-btn load';
+    loadBtn.textContent = 'Load';
+    loadBtn.onclick = () => loadProfile(name);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'profile-item-btn delete';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.onclick = () => removeProfile(name);
+
+    li.appendChild(label);
+    li.appendChild(loadBtn);
+    li.appendChild(deleteBtn);
+    list.appendChild(li);
+  });
+}
+
+// Save the current popout's rows as a named profile.
+function saveCurrentProfile() {
+  const input = document.getElementById('profileName');
+  const name = input ? input.value.trim() : '';
+  if (!name) {
+    showText('Enter a profile name to save.');
+    return;
+  }
+
+  sendMessage({ action: 'getCurrentRows' }, rows => {
+    if (chrome.runtime.lastError || !rows || !Array.isArray(rows.rows)) {
+      showText('Open Roll20 to save the current popout.');
+      return;
+    }
+    saveProfile(name, rows)
+      .then(() => {
+        if (input) {
+          input.value = '';
+        }
+        showText(`Saved profile "${name}".`);
+        renderProfiles();
+      })
+      .catch(() => showText('Failed to save profile.'));
+  });
+}
+
+// Apply a saved profile to the popout in the active Roll20 tab.
+function loadProfile(name) {
+  getProfiles().then(profiles => {
+    const profile = profiles[name];
+    if (!profile) {
+      showText('Profile not found.');
+      renderProfiles();
+      return;
+    }
+    sendMessage({ action: 'applyProfile', profile }, resp => {
+      if (chrome.runtime.lastError || !resp || !resp.success) {
+        showText('Open Roll20 to load a profile.');
+        return;
+      }
+      showText(`Loaded profile "${name}".`);
+    });
+  });
+}
+
+// Delete a saved profile.
+function removeProfile(name) {
+  deleteProfile(name)
+    .then(() => {
+      showText(`Deleted profile "${name}".`);
+      renderProfiles();
+    })
+    .catch(() => showText('Failed to delete profile.'));
+}
+
 // Listen on messages from injected JS
 chrome.runtime.onMessage.addListener((request, _sender, _sendResponse) => {
   if (request.action === 'showText') {
@@ -189,6 +306,21 @@ document.addEventListener('DOMContentLoaded', () => {
   if (hideModifierBtn) {
     hideModifierBtn.onclick = () => sendMessage({ action: 'hideModifier' });
   }
+
+  // Profiles UI
+  const saveProfileBtn = document.getElementById('saveProfile');
+  if (saveProfileBtn) {
+    saveProfileBtn.onclick = saveCurrentProfile;
+  }
+  const profileNameInput = document.getElementById('profileName');
+  if (profileNameInput) {
+    profileNameInput.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        saveCurrentProfile();
+      }
+    });
+  }
+  renderProfiles();
 
   detectAndApplyTheme();
 });

--- a/src/content/roll20.js
+++ b/src/content/roll20.js
@@ -90,6 +90,68 @@ if (typeof window.roll20PixelsLoaded === 'undefined') {
               window.hideModifierBox();
               break;
 
+            case 'getCurrentRows': {
+              // Return the current popout rows (names/order/values) for the
+              // popup to save as a profile. Prefer the live DOM; fall back to
+              // persisted rows so this works even when the box is hidden.
+              let rowsData = null;
+              const box = window.ModifierBox?.getElement?.();
+              if (box && window.ModifierBoxRowManager?.serializeRows) {
+                rowsData = window.ModifierBoxRowManager.serializeRows(box);
+              }
+              if (!rowsData || !rowsData.rows || rowsData.rows.length === 0) {
+                try {
+                  const stored = localStorage.getItem('pixels_modifier_rows');
+                  if (stored) {
+                    const parsed = JSON.parse(stored);
+                    rowsData = {
+                      rows: parsed.rows || [],
+                      selectedIndex:
+                        typeof parsed.selectedIndex === 'number'
+                          ? parsed.selectedIndex
+                          : -1,
+                    };
+                  }
+                } catch (e) {
+                  log(`Could not read stored rows: ${e.message}`);
+                }
+              }
+              sendResponse(rowsData || { rows: [], selectedIndex: -1 });
+              break;
+            }
+
+            case 'applyProfile': {
+              // Apply a saved profile's rows to the popout, creating/showing it
+              // first if necessary. Responds asynchronously.
+              (async () => {
+                try {
+                  // Ensure the box exists and is visible before applying.
+                  if (window.ModifierBox?.show) {
+                    await window.ModifierBox.show();
+                  }
+                  const box = window.ModifierBox?.getElement?.();
+                  const cb = () => {
+                    if (window.ModifierBox?.updateSelectedModifier) {
+                      window.ModifierBox.updateSelectedModifier();
+                    }
+                  };
+                  const ok =
+                    box && window.ModifierBoxRowManager?.applyProfileRows
+                      ? window.ModifierBoxRowManager.applyProfileRows(
+                          box,
+                          msg.profile,
+                          cb
+                        )
+                      : false;
+                  sendResponse({ success: Boolean(ok) });
+                } catch (e) {
+                  log(`Error applying profile: ${e.message}`);
+                  sendResponse({ success: false, error: e.message });
+                }
+              })();
+              return true; // keep the message channel open for async response
+            }
+
             case 'connect':
               // Handle connect asynchronously to catch all errors properly
               (async () => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -29,6 +29,7 @@
       ],
       "js": [
         "utils/modifierSettings.js",
+        "utils/profileStorage.js",
         "utils/themeDetector.js",
         "utils/cssLoader.js",
         "utils/htmlLoader.js",

--- a/src/utils/profileStorage.js
+++ b/src/utils/profileStorage.js
@@ -1,0 +1,188 @@
+'use strict';
+
+/**
+ * profileStorage.js
+ *
+ * Persistence wrapper for the Pixels Roll20 extension.
+ *
+ * Saved profiles (named sets of modifier rows) are written to BOTH
+ * chrome.storage.local and chrome.storage.sync. Reads prefer/merge sync and
+ * local per-profile by `savedAt` (last-write-wins). The minimized-state flag is
+ * stored in chrome.storage.local only, since it is a per-device UI preference.
+ *
+ * Why dual-write for profiles: chrome.storage.sync only propagates across
+ * devices on browsers wired to a sync backend (Chrome, Edge). On Brave / Opera /
+ * Vivaldi the sync API exists but silently behaves like local, so the local copy
+ * is always the source of truth there. Dual-write gives cross-device sync where
+ * available and correct single-device behavior everywhere, with no failure modes
+ * introduced (sync writes that exceed quota are caught and ignored).
+ */
+
+const PROFILES_KEY = 'pixels_profiles';
+const MINIMIZED_KEY = 'pixels_minimized';
+
+// Resolve a chrome.storage area ('local' | 'sync'), or null if it is not
+// available in this context (e.g. test environment without a storage mock).
+function area(name) {
+  try {
+    if (
+      typeof chrome !== 'undefined' &&
+      chrome.storage &&
+      chrome.storage[name]
+    ) {
+      return chrome.storage[name];
+    }
+  } catch {
+    // chrome is not accessible in this context
+  }
+  return null;
+}
+
+function hasLastError() {
+  try {
+    return Boolean(
+      typeof chrome !== 'undefined' &&
+        chrome.runtime &&
+        chrome.runtime.lastError
+    );
+  } catch {
+    return false;
+  }
+}
+
+// Promise wrapper around chrome.storage[area].get for a single key. Resolves
+// undefined if the area is unavailable or the read fails; never rejects.
+function readArea(name, key) {
+  const a = area(name);
+  if (!a) {
+    return Promise.resolve(undefined);
+  }
+  return new Promise(resolve => {
+    try {
+      a.get(key, result => {
+        if (hasLastError()) {
+          resolve(undefined);
+          return;
+        }
+        resolve(result ? result[key] : undefined);
+      });
+    } catch {
+      resolve(undefined);
+    }
+  });
+}
+
+// Promise wrapper around chrome.storage[area].set. Resolves true on success,
+// false on failure (e.g. sync quota exceeded). Never rejects, so a failed sync
+// write cannot break a save.
+function writeArea(name, key, value) {
+  const a = area(name);
+  if (!a) {
+    return Promise.resolve(false);
+  }
+  return new Promise(resolve => {
+    try {
+      a.set({ [key]: value }, () => {
+        resolve(!hasLastError());
+      });
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+// Merge two profile maps, keeping the newer entry per name by savedAt.
+function mergeProfiles(localProfiles, syncProfiles) {
+  const merged = { ...(localProfiles || {}) };
+  Object.entries(syncProfiles || {}).forEach(([name, profile]) => {
+    const existing = merged[name];
+    if (!existing || (profile?.savedAt || 0) >= (existing.savedAt || 0)) {
+      merged[name] = profile;
+    }
+  });
+  return merged;
+}
+
+// Return all saved profiles as a { name: { rows, selectedIndex, savedAt } } map.
+async function getProfiles() {
+  const [localProfiles, syncProfiles] = await Promise.all([
+    readArea('local', PROFILES_KEY),
+    readArea('sync', PROFILES_KEY),
+  ]);
+  return mergeProfiles(localProfiles, syncProfiles);
+}
+
+// Save (or overwrite) a profile by name. `data` is { rows, selectedIndex }.
+// Returns true if the local (source-of-truth) write succeeded.
+async function saveProfile(name, data) {
+  if (!name || typeof name !== 'string') {
+    return false;
+  }
+  const profiles = await getProfiles();
+  profiles[name] = {
+    rows: Array.isArray(data?.rows) ? data.rows : [],
+    selectedIndex: Number.isInteger(data?.selectedIndex)
+      ? data.selectedIndex
+      : -1,
+    savedAt: Date.now(),
+  };
+  const [localOk] = await Promise.all([
+    writeArea('local', PROFILES_KEY, profiles),
+    writeArea('sync', PROFILES_KEY, profiles),
+  ]);
+  return localOk;
+}
+
+// Delete a profile by name from both storage areas. Returns true if it existed.
+async function deleteProfile(name) {
+  const profiles = await getProfiles();
+  if (!name || !(name in profiles)) {
+    return false;
+  }
+  delete profiles[name];
+  await Promise.all([
+    writeArea('local', PROFILES_KEY, profiles),
+    writeArea('sync', PROFILES_KEY, profiles),
+  ]);
+  return true;
+}
+
+// Minimized flag — per-device UI preference, stored in local only.
+async function getMinimized() {
+  const value = await readArea('local', MINIMIZED_KEY);
+  return value === true;
+}
+
+async function setMinimized(value) {
+  return writeArea('local', MINIMIZED_KEY, Boolean(value));
+}
+
+const ProfileStorage = {
+  getProfiles,
+  saveProfile,
+  deleteProfile,
+  getMinimized,
+  setMinimized,
+  // Exposed for tests
+  mergeProfiles,
+  PROFILES_KEY,
+  MINIMIZED_KEY,
+};
+
+export {
+  getProfiles,
+  saveProfile,
+  deleteProfile,
+  getMinimized,
+  setMinimized,
+  mergeProfiles,
+  PROFILES_KEY,
+  MINIMIZED_KEY,
+};
+
+export default ProfileStorage;
+
+// Legacy global export for content-script consumers (matches repo convention).
+if (typeof window !== 'undefined') {
+  window.PixelsProfileStorage = ProfileStorage;
+}

--- a/src/utils/profileStorage.js
+++ b/src/utils/profileStorage.js
@@ -20,6 +20,8 @@
 
 const PROFILES_KEY = 'pixels_profiles';
 const MINIMIZED_KEY = 'pixels_minimized';
+const ACTIVE_KEY = 'pixels_active_profile';
+const EXPORT_TYPE = 'pixels-roll20-profiles';
 
 // Resolve a chrome.storage area ('local' | 'sync'), or null if it is not
 // available in this context (e.g. test environment without a storage mock).
@@ -157,16 +159,103 @@ async function setMinimized(value) {
   return writeArea('local', MINIMIZED_KEY, Boolean(value));
 }
 
+// Active profile — which saved profile is currently loaded. Per-device, stored
+// in local only. Returns null when none is active.
+async function getActiveProfile() {
+  const value = await readArea('local', ACTIVE_KEY);
+  return typeof value === 'string' && value ? value : null;
+}
+
+async function setActiveProfile(name) {
+  return writeArea('local', ACTIVE_KEY, typeof name === 'string' ? name : '');
+}
+
+// Build a serializable bundle of all profiles for export to a file.
+async function exportProfiles() {
+  const profiles = await getProfiles();
+  return {
+    type: EXPORT_TYPE,
+    version: 1,
+    exportedAt: Date.now(),
+    profiles,
+  };
+}
+
+// Return a name not already present in `existingNames` (a Set), appending
+// " (2)", " (3)", ... as needed. Implements the keep-both import strategy.
+function uniqueName(base, existingNames) {
+  if (!existingNames.has(base)) {
+    return base;
+  }
+  let n = 2;
+  let candidate = `${base} (${n})`;
+  while (existingNames.has(candidate)) {
+    n += 1;
+    candidate = `${base} (${n})`;
+  }
+  return candidate;
+}
+
+// Merge an exported bundle into the saved profiles. On name collision the
+// incoming profile is kept under a renamed key (never overwrites existing).
+// Returns { imported, skipped }.
+async function importProfiles(bundle) {
+  const incoming =
+    bundle && bundle.profiles && typeof bundle.profiles === 'object'
+      ? bundle.profiles
+      : null;
+  if (!incoming) {
+    return { imported: 0, skipped: 0, error: 'invalid' };
+  }
+
+  const profiles = await getProfiles();
+  const names = new Set(Object.keys(profiles));
+  let imported = 0;
+  let skipped = 0;
+
+  Object.entries(incoming).forEach(([name, profile]) => {
+    if (!profile || !Array.isArray(profile.rows)) {
+      skipped += 1;
+      return;
+    }
+    const finalName = uniqueName(name, names);
+    profiles[finalName] = {
+      rows: profile.rows,
+      selectedIndex: Number.isInteger(profile.selectedIndex)
+        ? profile.selectedIndex
+        : -1,
+      savedAt: Date.now(),
+    };
+    names.add(finalName);
+    imported += 1;
+  });
+
+  if (imported > 0) {
+    await Promise.all([
+      writeArea('local', PROFILES_KEY, profiles),
+      writeArea('sync', PROFILES_KEY, profiles),
+    ]);
+  }
+
+  return { imported, skipped };
+}
+
 const ProfileStorage = {
   getProfiles,
   saveProfile,
   deleteProfile,
   getMinimized,
   setMinimized,
+  getActiveProfile,
+  setActiveProfile,
+  exportProfiles,
+  importProfiles,
   // Exposed for tests
   mergeProfiles,
+  uniqueName,
   PROFILES_KEY,
   MINIMIZED_KEY,
+  ACTIVE_KEY,
 };
 
 export {
@@ -175,9 +264,15 @@ export {
   deleteProfile,
   getMinimized,
   setMinimized,
+  getActiveProfile,
+  setActiveProfile,
+  exportProfiles,
+  importProfiles,
   mergeProfiles,
+  uniqueName,
   PROFILES_KEY,
   MINIMIZED_KEY,
+  ACTIVE_KEY,
 };
 
 export default ProfileStorage;

--- a/tests/jest/components/modifierBox/rowManager.test.js
+++ b/tests/jest/components/modifierBox/rowManager.test.js
@@ -922,6 +922,82 @@ describe('ModifierBox Row Manager', () => {
     // ...existing code...
   });
 
+  describe('serializeRows / applyRows', () => {
+    test('serializeRows captures names, values and selection in DOM order', () => {
+      const box = createMockModifierBox();
+
+      const data = window.ModifierBoxRowManager.serializeRows(box);
+
+      expect(data.rows).toEqual([
+        { name: 'Modifier 1', value: '0', originalIndex: '0' },
+      ]);
+      expect(data.selectedIndex).toBe(0);
+    });
+
+    test('serializeRows handles a null box', () => {
+      const data = window.ModifierBoxRowManager.serializeRows(null);
+      expect(data).toEqual({ rows: [], selectedIndex: -1 });
+    });
+
+    test('applyRows rebuilds the rows and restores selection', () => {
+      const box = createMockModifierBox();
+
+      const ok = window.ModifierBoxRowManager.applyRows(
+        box,
+        {
+          rows: [
+            { name: 'Bless', value: '1' },
+            { name: 'Rage', value: '2' },
+          ],
+          selectedIndex: 1,
+        },
+        null
+      );
+
+      expect(ok).toBe(true);
+
+      const rows = box.querySelectorAll('.modifier-row');
+      expect(rows.length).toBe(2);
+      expect(rows[0].querySelector('.modifier-name').value).toBe('Bless');
+      expect(rows[1].querySelector('.modifier-name').value).toBe('Rage');
+
+      const checked = box.querySelector(
+        'input[name="modifier-select"]:checked'
+      );
+      expect(checked.value).toBe('1');
+    });
+
+    test('applyRows is a round-trip with serializeRows', () => {
+      const box = createMockModifierBox();
+      window.ModifierBoxRowManager.applyRows(
+        box,
+        {
+          rows: [
+            { name: 'A', value: '3' },
+            { name: 'B', value: '-1' },
+          ],
+          selectedIndex: 0,
+        },
+        null
+      );
+
+      const data = window.ModifierBoxRowManager.serializeRows(box);
+      expect(data.rows.map(r => r.name)).toEqual(['A', 'B']);
+      expect(data.rows.map(r => r.value)).toEqual(['3', '-1']);
+      expect(data.selectedIndex).toBe(0);
+    });
+
+    test('applyRows returns false for invalid input', () => {
+      const box = createMockModifierBox();
+      expect(window.ModifierBoxRowManager.applyRows(box, null, null)).toBe(
+        false
+      );
+      expect(
+        window.ModifierBoxRowManager.applyRows(box, { rows: 'nope' }, null)
+      ).toBe(false);
+    });
+  });
+
   // Helper function to create a mock modifier box
   function createMockModifierBox() {
     const box = document.createElement('div');

--- a/tests/jest/utils/profileStorage.test.js
+++ b/tests/jest/utils/profileStorage.test.js
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const profileStorage = require('../../../src/utils/profileStorage.js');
+
+// In-memory chrome.storage area mock.
+function makeArea() {
+  const store = {};
+  return {
+    _store: store,
+    get: jest.fn((key, cb) => {
+      const result = {};
+      if (typeof key === 'string' && key in store) {
+        result[key] = store[key];
+      }
+      cb(result);
+    }),
+    set: jest.fn((obj, cb) => {
+      Object.assign(store, obj);
+      cb();
+    }),
+  };
+}
+
+// Area whose set() fails (simulates sync quota exceeded) by raising lastError.
+function makeFailingArea() {
+  const area = makeArea();
+  area.set = jest.fn((obj, cb) => {
+    chrome.runtime.lastError = { message: 'QUOTA_BYTES quota exceeded' };
+    cb();
+    delete chrome.runtime.lastError;
+  });
+  return area;
+}
+
+describe('profileStorage', () => {
+  let local;
+  let sync;
+
+  beforeEach(() => {
+    resetMocks();
+    local = makeArea();
+    sync = makeArea();
+    chrome.storage = { local, sync };
+    delete chrome.runtime.lastError;
+  });
+
+  describe('saveProfile / getProfiles', () => {
+    test('writes the profile to BOTH local and sync', async () => {
+      const ok = await profileStorage.saveProfile('Combat', {
+        rows: [{ name: 'Rage', value: '2' }],
+        selectedIndex: 0,
+      });
+
+      expect(ok).toBe(true);
+      expect(local._store.pixels_profiles.Combat.rows).toEqual([
+        { name: 'Rage', value: '2' },
+      ]);
+      expect(sync._store.pixels_profiles.Combat.rows).toEqual([
+        { name: 'Rage', value: '2' },
+      ]);
+      expect(local._store.pixels_profiles.Combat.savedAt).toEqual(
+        expect.any(Number)
+      );
+    });
+
+    test('rejects an empty profile name', async () => {
+      const ok = await profileStorage.saveProfile('', { rows: [] });
+      expect(ok).toBe(false);
+      expect(local._store.pixels_profiles).toBeUndefined();
+    });
+
+    test('a sync write failure does not break the save (local wins)', async () => {
+      sync = makeFailingArea();
+      chrome.storage = { local, sync };
+
+      const ok = await profileStorage.saveProfile('Solo', {
+        rows: [{ name: 'Bless', value: '1' }],
+        selectedIndex: 0,
+      });
+
+      expect(ok).toBe(true); // local succeeded
+      expect(local._store.pixels_profiles.Solo).toBeDefined();
+      expect(sync._store.pixels_profiles).toBeUndefined();
+    });
+
+    test('getProfiles returns a merged map', async () => {
+      await profileStorage.saveProfile('A', { rows: [], selectedIndex: -1 });
+      const profiles = await profileStorage.getProfiles();
+      expect(Object.keys(profiles)).toContain('A');
+    });
+  });
+
+  describe('mergeProfiles', () => {
+    test('keeps the newer entry per name by savedAt', () => {
+      const localProfiles = {
+        A: { rows: [{ name: 'old' }], savedAt: 100 },
+        B: { rows: [], savedAt: 50 },
+      };
+      const syncProfiles = {
+        A: { rows: [{ name: 'new' }], savedAt: 200 },
+        C: { rows: [], savedAt: 10 },
+      };
+
+      const merged = profileStorage.mergeProfiles(localProfiles, syncProfiles);
+
+      expect(merged.A.rows[0].name).toBe('new'); // sync newer
+      expect(merged.B).toBeDefined(); // local-only kept
+      expect(merged.C).toBeDefined(); // sync-only kept
+    });
+
+    test('handles undefined inputs', () => {
+      expect(profileStorage.mergeProfiles(undefined, undefined)).toEqual({});
+    });
+  });
+
+  describe('deleteProfile', () => {
+    test('removes a profile from both areas', async () => {
+      await profileStorage.saveProfile('Temp', { rows: [], selectedIndex: -1 });
+      const removed = await profileStorage.deleteProfile('Temp');
+
+      expect(removed).toBe(true);
+      expect(local._store.pixels_profiles.Temp).toBeUndefined();
+      expect(sync._store.pixels_profiles.Temp).toBeUndefined();
+    });
+
+    test('returns false for an unknown profile', async () => {
+      const removed = await profileStorage.deleteProfile('Nope');
+      expect(removed).toBe(false);
+    });
+  });
+
+  describe('minimized flag', () => {
+    test('setMinimized writes to local only, getMinimized reads it', async () => {
+      const ok = await profileStorage.setMinimized(true);
+
+      expect(ok).toBe(true);
+      expect(local._store.pixels_minimized).toBe(true);
+      expect(sync._store.pixels_minimized).toBeUndefined();
+      expect(await profileStorage.getMinimized()).toBe(true);
+    });
+
+    test('defaults to false when unset', async () => {
+      expect(await profileStorage.getMinimized()).toBe(false);
+    });
+  });
+
+  describe('graceful degradation', () => {
+    test('getProfiles resolves to {} when chrome.storage is absent', async () => {
+      delete chrome.storage;
+      expect(await profileStorage.getProfiles()).toEqual({});
+    });
+
+    test('saveProfile resolves false when chrome.storage is absent', async () => {
+      delete chrome.storage;
+      expect(await profileStorage.saveProfile('X', { rows: [] })).toBe(false);
+    });
+  });
+});

--- a/tests/jest/utils/profileStorage.test.js
+++ b/tests/jest/utils/profileStorage.test.js
@@ -157,4 +157,82 @@ describe('profileStorage', () => {
       expect(await profileStorage.saveProfile('X', { rows: [] })).toBe(false);
     });
   });
+
+  describe('active profile', () => {
+    test('set then get returns the name; local only', async () => {
+      const ok = await profileStorage.setActiveProfile('Combat');
+      expect(ok).toBe(true);
+      expect(local._store.pixels_active_profile).toBe('Combat');
+      expect(sync._store.pixels_active_profile).toBeUndefined();
+      expect(await profileStorage.getActiveProfile()).toBe('Combat');
+    });
+
+    test('defaults to null and clears to null', async () => {
+      expect(await profileStorage.getActiveProfile()).toBeNull();
+      await profileStorage.setActiveProfile('Combat');
+      await profileStorage.setActiveProfile('');
+      expect(await profileStorage.getActiveProfile()).toBeNull();
+    });
+  });
+
+  describe('uniqueName', () => {
+    test('returns the base name when free', () => {
+      expect(profileStorage.uniqueName('A', new Set())).toBe('A');
+    });
+
+    test('appends an incrementing suffix on collision', () => {
+      const names = new Set(['A', 'A (2)']);
+      expect(profileStorage.uniqueName('A', names)).toBe('A (3)');
+    });
+  });
+
+  describe('exportProfiles / importProfiles', () => {
+    test('exportProfiles returns a typed bundle of all profiles', async () => {
+      await profileStorage.saveProfile('Combat', {
+        rows: [{ name: 'Rage', value: '2' }],
+        selectedIndex: 0,
+      });
+
+      const bundle = await profileStorage.exportProfiles();
+
+      expect(bundle.type).toBe('pixels-roll20-profiles');
+      expect(bundle.version).toBe(1);
+      expect(bundle.profiles.Combat).toBeDefined();
+    });
+
+    test('importProfiles keeps both on name collision (rename)', async () => {
+      await profileStorage.saveProfile('Combat', {
+        rows: [{ name: 'original', value: '0' }],
+        selectedIndex: 0,
+      });
+
+      const result = await profileStorage.importProfiles({
+        type: 'pixels-roll20-profiles',
+        profiles: {
+          Combat: {
+            rows: [{ name: 'imported', value: '9' }],
+            selectedIndex: 0,
+          },
+        },
+      });
+
+      expect(result.imported).toBe(1);
+
+      const profiles = await profileStorage.getProfiles();
+      // Original is untouched, the import landed under a renamed key.
+      expect(profiles.Combat.rows[0].name).toBe('original');
+      expect(profiles['Combat (2)'].rows[0].name).toBe('imported');
+    });
+
+    test('importProfiles skips invalid entries and reports an invalid bundle', async () => {
+      const skipResult = await profileStorage.importProfiles({
+        profiles: { Bad: { notRows: true } },
+      });
+      expect(skipResult.imported).toBe(0);
+      expect(skipResult.skipped).toBe(1);
+
+      const badResult = await profileStorage.importProfiles({ nope: true });
+      expect(badResult.error).toBe('invalid');
+    });
+  });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
 
     // Utility modules
     'utils/modifierSettings': './src/utils/modifierSettings.js',
+    'utils/profileStorage': './src/utils/profileStorage.js',
     'utils/themeDetector': './src/utils/themeDetector.js',
     'utils/cssLoader': './src/utils/cssLoader.js',
     'utils/htmlLoader': './src/utils/htmlLoader.js',


### PR DESCRIPTION
Save/load named popout profiles (modifier names, order, values) from the
extension popup, backed by a dual-write storage wrapper (profileStorage.js)
that writes to both chrome.storage.local and chrome.storage.sync and reads
sync-first with per-profile last-write-wins merge. Sync quota failures degrade
gracefully to local.

Separately persists the modifier box minimized/full-size state (local-only,
per-device) so it's restored on reload, independent of any active profile.

- Reusable serializeRows/applyRows helpers in rowManager
- getCurrentRows/applyProfile content-script message handlers
- Profiles UI in the popup; restore minimize state on box init
- Tests for profileStorage + serialize/apply round-trip (205 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)