### PR TITLE
Improve Bluetooth connection reliability and fix stale UI status

### DIFF
--- a/specs/bluetooth-connection-reliability.md
+++ b/specs/bluetooth-connection-reliability.md
@@ -1,0 +1,122 @@
+# Bluetooth Connection Reliability
+
+**Status:** In Progress
+**Created:** 2026-03-18
+
+## Problem
+
+Pixels dice frequently drop Bluetooth connections and the extension popup continues to show "connected" when the die is actually disconnected. Users must manually re-pair dice to restore functionality.
+
+### Root Causes
+
+1. **No modern reconnection APIs** — `getDevices()` and `watchAdvertisements()` are not used, so the extension can't silently reconnect to previously-permitted dice without a user gesture
+2. **Stale UI state** — the popup only updates when it receives a message from the content script; silent disconnections leave the popup showing "connected"
+3. **`_device` reference destroyed on disconnect** — `markDisconnected()` nulls `_device` (line 137 of PixelsBluetooth.js), making reconnection via the device reference impossible
+4. **Duplicate `gattserverdisconnected` listeners** — each call to `connectToNewPixel()` adds a new listener (line 406) without removing old ones, causing multiple simultaneous reconnection attempts that compete with each other
+5. **Wrong legacy UUID** — `PIXELS_LEGACY_NOTIFY_CHARACTERISTIC` is set to `6e400001-...` (the service UUID) instead of `6e400003-...` (the Nordic UART TX/notify characteristic)
+6. **Polling-only reconnection** — 30-second interval polling is slow and can miss the die when it briefly comes back in range
+
+## Solution
+
+### 1. Fix Legacy Notify UUID
+
+**File:** `src/content/modules/PixelsBluetooth.js`
+
+Change `PIXELS_LEGACY_NOTIFY_CHARACTERISTIC` from `6e400001-b5a3-f393-e0a9-e50e24dcca9e` to `6e400003-b5a3-f393-e0a9-e50e24dcca9e`. The Nordic UART Service (NUS) defines:
+- `6e400001` — Service UUID
+- `6e400002` — RX (write) characteristic
+- `6e400003` — TX (notify) characteristic
+
+### 2. Preserve `_device` Reference Across Disconnections
+
+**File:** `src/content/modules/PixelsBluetooth.js`
+
+In `markDisconnected()`:
+- Continue to null `_server` and `_notify` (these are invalidated on GATT disconnect)
+- **Keep `_device` alive** — it holds the browser's permission grant and is needed for `device.gatt.connect()` and `device.watchAdvertisements()`
+- Add a separate `destroy()` method for permanent removal (used by the 6-hour cleanup)
+
+### 3. Fix Duplicate Event Listeners
+
+**File:** `src/content/modules/PixelsBluetooth.js`
+
+- Add a `_hasDisconnectListener` flag to each pixel
+- Before adding `gattserverdisconnected` listener in `connectToNewPixel()`, check if one is already registered
+- Use a named handler function that can be properly removed and re-added
+- Re-register after successful reconnection
+
+### 4. Dual-Path Reconnection Strategy
+
+**File:** `src/content/modules/PixelsBluetooth.js`
+
+Add a module-level variable:
+```
+let reconnectionStrategy = 'unknown'; // 'unknown' | 'watch' | 'poll'
+```
+
+On disconnect, determine reconnection approach:
+
+```
+if strategy is 'unknown':
+    Race: start watchAdvertisements() vs 10-second timeout
+    If advertisementreceived fires first:
+        → set strategy = 'watch'
+        → reconnect via device.gatt.connect()
+    If timeout fires first:
+        → abort watchAdvertisements()
+        → set strategy = 'poll'
+        → fall back to polling reconnection (current behavior)
+
+if strategy is 'watch':
+    Use watchAdvertisements() directly (no race needed)
+
+if strategy is 'poll':
+    Use polling reconnection directly (current exponential backoff)
+```
+
+This automatically detects Linux (where `watchAdvertisements()` silently fails) and caches the result so subsequent disconnects skip the detection phase.
+
+### 5. `getDevices()` on Page Load
+
+**File:** `src/content/modules/PixelsBluetooth.js` — `initialize()`
+
+On module initialization:
+1. Check if `navigator.bluetooth.getDevices` exists
+2. Call `getDevices()` to retrieve previously-permitted Pixels dice
+3. For each device, attempt reconnection using the dual-path strategy
+4. Update popup status as dice reconnect
+5. This enables silent reconnection after page refresh without requiring the user to click "Connect" again
+
+### 6. Fix Stale Connection Status in Popup
+
+**Files:** `src/content/modules/PixelsBluetooth.js`, `src/core/extensionMessaging.js`, `src/components/popup/popup.js`
+
+Three changes:
+
+**A. Active GATT verification on status request**
+When the content script receives a `getStatus` message, verify the actual GATT connection state of each pixel before responding. Don't just read the cached `_isConnected` flag — check `device.gatt.connected` and update internal state if they disagree.
+
+**B. Status push after every reconnection attempt**
+After any reconnection attempt (success or failure), always call `sendStatusToExtension()` so the popup stays in sync.
+
+**C. Popup-side polling**
+When the popup is open, poll `getStatus` every 5 seconds. This catches any silent state changes that weren't pushed. Clear the interval when the popup closes (it naturally cleans up since popups are destroyed on close).
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src/content/modules/PixelsBluetooth.js` | UUID fix, preserve _device, fix listeners, dual-path reconnection, getDevices() |
+| `src/core/extensionMessaging.js` | Active GATT verification in status response |
+| `src/components/popup/popup.js` | 5-second status polling while open |
+
+## Verification Plan
+
+1. **Connect a Pixels die** — verify popup shows "connected"
+2. **Turn die off or move out of range** — verify popup updates to "disconnected" within ~30 seconds
+3. **Turn die back on** — verify automatic reconnection (instant on Windows/macOS via watchAdvertisements, polling-based on Linux)
+4. **Refresh the Roll20 page** — verify `getDevices()` picks up previously-permitted dice and reconnects silently
+5. **Open/close popup repeatedly** — verify status is always accurate, never stale
+6. **Connect multiple dice, disconnect one** — verify correct count shown (e.g., "1/2 Pixels connected")
+7. **Run existing tests** — `npm test` should pass
+8. **Linux-specific test** — verify the strategy detection falls back to `'poll'` and reconnection still works via exponential backoff

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -163,8 +163,10 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
     // Request initial status from the content script
     sendMessage({ action: 'getStatus' });
 
-    // Don't automatically override modifier values on popup initialization
-    // Let the content script sync FROM the UI instead of overwriting it
+    // Poll status every 5 seconds while popup is open to catch silent state changes
+    setInterval(() => {
+      sendMessage({ action: 'getStatus' });
+    }, 5000);
   }
 });
 

--- a/src/content/modules/PixelsBluetooth.js
+++ b/src/content/modules/PixelsBluetooth.js
@@ -26,12 +26,15 @@ const _PIXELS_WRITE_CHARACTERISTIC = 'a6b90003-7a5a-43f2-a962-350c8edc9b5b';
 // Legacy Pixels dice UUIDs (for older dice)
 const PIXELS_LEGACY_SERVICE_UUID = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const PIXELS_LEGACY_NOTIFY_CHARACTERISTIC =
-  '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
+  '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
 const _PIXELS_LEGACY_WRITE_CHARACTERISTIC =
   '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 
 // Global pixels array
 const pixels = [];
+
+// Reconnection strategy: 'unknown' until first attempt, then 'watch' or 'poll'
+let reconnectionStrategy = 'unknown';
 
 // Roll formulas
 const pixelsFormulaWithModifier =
@@ -93,32 +96,30 @@ export const createPixel = (name, server, device) => {
       // This allows for hours between dice rolls without disconnecting
       if (_isConnected && _device) {
         try {
-          // Only disconnect if GATT is actually disconnected, not based on activity timeout
           if (_device.gatt && !_device.gatt.connected) {
             log(`Pixel ${_name} GATT connection lost, marking as disconnected`);
+            const deviceRef = _device; // Capture before markDisconnected
             markDisconnected();
-            // Attempt reconnection after GATT disconnection
             setTimeout(() => {
-              if (!_isConnected && _device && _pixelSelf) {
-                attemptReconnection(_device, _pixelSelf);
+              if (!_isConnected && deviceRef && _pixelSelf) {
+                attemptReconnection(deviceRef, _pixelSelf);
               }
             }, 5000);
           }
         } catch (error) {
-          // GATT access failed, likely disconnected
           log(
             `Pixel ${_name} GATT access failed, marking as disconnected: ${error.message}`
           );
+          const deviceRef = _device;
           markDisconnected();
-          // Attempt reconnection after GATT failure
           setTimeout(() => {
-            if (!_isConnected && _device && _pixelSelf) {
-              attemptReconnection(_device, _pixelSelf);
+            if (!_isConnected && deviceRef && _pixelSelf) {
+              attemptReconnection(deviceRef, _pixelSelf);
             }
           }, 5000);
         }
       }
-    }, 30000); // Check every 30 seconds - less frequent since we're only checking GATT state
+    }, 30000);
   };
 
   let _disconnectionTimeout = null;
@@ -132,9 +133,8 @@ export const createPixel = (name, server, device) => {
 
     _disconnectionTimeout = setTimeout(() => {
       if (_isConnected) {
-        // Double-check we still need to disconnect
         _isConnected = false;
-        _device = null;
+        // Keep _device alive for reconnection (gatt.connect, watchAdvertisements)
         _server = null;
 
         // Clean up notification listener
@@ -158,15 +158,20 @@ export const createPixel = (name, server, device) => {
           _connectionMonitor = null;
         }
         log(`Pixel ${_name} marked as disconnected`);
+        sendStatusToExtension();
       }
       _disconnectionTimeout = null;
     }, 1000); // 1 second debounce
   };
 
-  const reconnect = (server, notify) => {
+  const reconnect = (server, notify, device) => {
     _server = server;
     _isConnected = true;
     _lastActivity = Date.now();
+
+    if (device) {
+      _device = device;
+    }
 
     // Clear any pending disconnection timeout
     if (_disconnectionTimeout) {
@@ -180,12 +185,20 @@ export const createPixel = (name, server, device) => {
     }
 
     log(`Pixel ${_name} reconnected successfully`);
+    sendStatusToExtension();
   };
 
   const disconnect = () => {
     markDisconnected();
     _server?.disconnect();
     log(`Pixel ${_name} manually disconnected`);
+  };
+
+  // Permanent removal — nulls _device so it can't be reconnected
+  const destroy = () => {
+    disconnect();
+    _device = null;
+    log(`Pixel ${_name} destroyed`);
   };
 
   const handleNotifications = event => {
@@ -308,6 +321,7 @@ export const createPixel = (name, server, device) => {
     markDisconnected,
     reconnect,
     disconnect,
+    destroy,
     handleNotifications,
     updateActivity() {
       _lastActivity = Date.now();
@@ -332,6 +346,7 @@ export const createPixel = (name, server, device) => {
       return _lastActivity;
     },
     _reconnectAttempts: 0, // Initialize reconnection attempt counter
+    _hasDisconnectListener: false,
   };
 
   // Store self-reference for reconnection
@@ -403,15 +418,19 @@ const connectToNewPixel = async () => {
     pixel.updateActivity();
     pixel.startConnectionMonitoring();
 
-    device.addEventListener('gattserverdisconnected', () => {
-      log(`Device ${device.name} disconnected`);
-      pixel.markDisconnected();
+    // Only add disconnect listener if not already registered
+    if (!pixel._hasDisconnectListener) {
+      device.addEventListener('gattserverdisconnected', () => {
+        log(`Device ${device.name} disconnected`);
+        pixel.markDisconnected();
 
-      // Attempt reconnection after GATT disconnection
-      setTimeout(() => {
-        attemptReconnection(device, pixel);
-      }, 5000);
-    });
+        // Attempt reconnection after GATT disconnection
+        setTimeout(() => {
+          attemptReconnection(device, pixel);
+        }, 5000);
+      });
+      pixel._hasDisconnectListener = true;
+    }
 
     log(`Connected to ${device.name}`);
     sendTextToExtension(`Connected to ${device.name}`);
@@ -440,57 +459,98 @@ const _handleDeviceDisconnection = device => {
   }
 };
 
-// Attempt to reconnect to a disconnected device
-const attemptReconnection = async (device, pixel) => {
+// Core GATT reconnection — connects to device and sets up services/notifications
+const performGattReconnection = async (device, pixel) => {
+  // Ensure clean state before reconnecting
   try {
-    // Check if device is actually disconnected before attempting reconnection
-    if (device.gatt.connected) {
-      log(`Device ${device.name} is already connected, skipping reconnection`);
-      return;
-    }
-  } catch (error) {
-    log(
-      `Cannot check GATT state for ${device.name}, proceeding with reconnection: ${error.message}`
-    );
-  }
-
-  log(`Attempting to reconnect to ${device.name}`);
-  try {
-    // Ensure clean state before reconnecting
     if (device.gatt.connected) {
       device.gatt.disconnect();
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
+  } catch {
+    // GATT state might be inaccessible, continue anyway
+  }
 
-    const server = await device.gatt.connect();
-    await new Promise(resolve => setTimeout(resolve, 500));
+  const server = await device.gatt.connect();
+  await new Promise(resolve => setTimeout(resolve, 500));
 
-    if (!server.connected) {
-      throw new Error('Connection lost immediately after connecting');
+  if (!server.connected) {
+    throw new Error('Connection lost immediately after connecting');
+  }
+
+  let service, notifyUuid;
+  try {
+    service = await server.getPrimaryService(PIXELS_SERVICE_UUID);
+    notifyUuid = PIXELS_NOTIFY_CHARACTERISTIC;
+    log('Reconnecting to modern Pixels die');
+  } catch {
+    service = await server.getPrimaryService(PIXELS_LEGACY_SERVICE_UUID);
+    notifyUuid = PIXELS_LEGACY_NOTIFY_CHARACTERISTIC;
+    log('Reconnecting to legacy Pixels die');
+  }
+
+  const notify = await service.getCharacteristic(notifyUuid);
+  await notify.startNotifications();
+
+  pixel.reconnect(server, notify, device);
+  sendTextToExtension(`Reconnected to ${pixel.name}`);
+  log(`Successfully reconnected to ${device.name}`);
+
+  pixel.startConnectionMonitoring();
+  pixel._reconnectAttempts = 0;
+};
+
+// Watch-based reconnection — uses watchAdvertisements() for instant reconnection
+const attemptWatchReconnection = (device, pixel) => {
+  return new Promise((resolve, reject) => {
+    const abortController = new AbortController();
+
+    device.addEventListener(
+      'advertisementreceived',
+      async () => {
+        abortController.abort();
+        try {
+          await performGattReconnection(device, pixel);
+          resolve('watch');
+        } catch (error) {
+          reject(error);
+        }
+      },
+      { once: true }
+    );
+
+    device
+      .watchAdvertisements({ signal: abortController.signal })
+      .catch(error => {
+        if (error.name !== 'AbortError') {
+          reject(error);
+        }
+      });
+
+    // Race timeout — if no advertisement in 10s, watchAdvertisements isn't working
+    setTimeout(() => {
+      abortController.abort();
+      reject(new Error('watchAdvertisements timeout'));
+    }, 10000);
+  });
+};
+
+// Poll-based reconnection — exponential backoff GATT connect attempts
+const attemptPollReconnection = async (device, pixel) => {
+  try {
+    // Check if device is actually disconnected
+    if (device.gatt && device.gatt.connected) {
+      log(`Device ${device.name} is already connected, skipping reconnection`);
+      return;
     }
+  } catch {
+    // GATT state inaccessible, proceed with reconnection
+  }
 
-    let service, notifyUuid;
-    try {
-      service = await server.getPrimaryService(PIXELS_SERVICE_UUID);
-      notifyUuid = PIXELS_NOTIFY_CHARACTERISTIC;
-      log('Reconnecting to modern Pixels die');
-    } catch {
-      service = await server.getPrimaryService(PIXELS_LEGACY_SERVICE_UUID);
-      notifyUuid = PIXELS_LEGACY_NOTIFY_CHARACTERISTIC;
-      log('Reconnecting to legacy Pixels die');
-    }
-
-    const notify = await service.getCharacteristic(notifyUuid);
-    await notify.startNotifications();
-
-    pixel.reconnect(server, notify);
-    sendTextToExtension(`Reconnected to ${pixel.name}`);
-    log(`Successfully reconnected to ${device.name}`);
-
-    pixel.startConnectionMonitoring();
-    pixel._reconnectAttempts = 0;
+  try {
+    await performGattReconnection(device, pixel);
   } catch (error) {
-    log(`Failed to reconnect to ${device.name}: ${error}`);
+    log(`Poll reconnection failed for ${device.name}: ${error}`);
 
     pixel._reconnectAttempts = (pixel._reconnectAttempts || 0) + 1;
     const maxAttempts = 5;
@@ -505,13 +565,49 @@ const attemptReconnection = async (device, pixel) => {
       );
 
       setTimeout(() => {
-        attemptReconnection(device, pixel);
+        attemptPollReconnection(device, pixel);
       }, delay);
     } else {
       log(`Max reconnection attempts reached for ${device.name}. Giving up.`);
       sendTextToExtension(
         `Failed to reconnect to ${pixel.name} after ${maxAttempts} attempts`
       );
+      sendStatusToExtension();
+    }
+  }
+};
+
+// Attempt to reconnect to a disconnected device using dual-path strategy
+const attemptReconnection = async (device, pixel) => {
+  if (!device) {
+    log('Cannot reconnect: device reference is null');
+    return;
+  }
+
+  log(`Attempting to reconnect to ${device.name} (strategy: ${reconnectionStrategy})`);
+
+  if (reconnectionStrategy === 'watch') {
+    // Known working — go straight to watch
+    try {
+      await attemptWatchReconnection(device, pixel);
+    } catch {
+      log(`Watch reconnection failed for ${device.name}, falling back to poll`);
+      attemptPollReconnection(device, pixel);
+    }
+  } else if (reconnectionStrategy === 'poll') {
+    // Known that watch doesn't work — go straight to poll
+    attemptPollReconnection(device, pixel);
+  } else {
+    // Unknown — race watch vs timeout to detect platform support
+    log('Detecting reconnection strategy (watch vs poll)...');
+    try {
+      await attemptWatchReconnection(device, pixel);
+      reconnectionStrategy = 'watch';
+      log('Reconnection strategy set to: watch (watchAdvertisements works)');
+    } catch {
+      reconnectionStrategy = 'poll';
+      log('Reconnection strategy set to: poll (watchAdvertisements unavailable)');
+      attemptPollReconnection(device, pixel);
     }
   }
 };
@@ -553,7 +649,7 @@ const setupGlobalCleanup = () => {
           log(
             `Removing very stale pixel connection: ${pixel.name} (inactive for ${sixHours / (60 * 60 * 1000)} hours)`
           );
-          pixel.disconnect();
+          pixel.destroy();
           return false;
         }
         return true;
@@ -570,6 +666,45 @@ const setupGlobalCleanup = () => {
   }
 };
 
+// Attempt silent reconnection to previously-permitted devices
+const reconnectKnownDevices = async () => {
+  if (!navigator.bluetooth || !navigator.bluetooth.getDevices) {
+    log('getDevices() not available, skipping silent reconnection');
+    return;
+  }
+
+  try {
+    const devices = await navigator.bluetooth.getDevices();
+    if (devices.length === 0) {
+      log('No previously-permitted Bluetooth devices found');
+      return;
+    }
+
+    log(`Found ${devices.length} previously-permitted device(s), attempting reconnection`);
+
+    for (const device of devices) {
+      // Skip if already connected
+      const existingPixel = getPixelByDeviceId(device.id, pixels);
+      if (existingPixel && isConnected(existingPixel)) {
+        continue;
+      }
+
+      // Create or reuse pixel entry
+      let pixel = existingPixel;
+      if (!pixel) {
+        pixel = createPixel(device.name || 'Unknown Pixel', null, device);
+        pixel._isConnected = false;
+        pixels.push(pixel);
+      }
+
+      // Attempt reconnection using dual-path strategy
+      attemptReconnection(device, pixel);
+    }
+  } catch (error) {
+    log(`Silent reconnection failed: ${error.message}`);
+  }
+};
+
 // Initialize the module
 export const initialize = () => {
   log('PixelsBluetooth module initialized with ES modules and Ramda');
@@ -577,6 +712,9 @@ export const initialize = () => {
 
   // Set up global variables for backwards compatibility
   window.pixels = pixels;
+
+  // Attempt to reconnect previously-permitted devices
+  reconnectKnownDevices();
 
   return {
     connectToPixel,

--- a/src/core/extensionMessaging.js
+++ b/src/core/extensionMessaging.js
@@ -33,8 +33,17 @@ export const sendTextToExtension = txt => {
 };
 
 export const sendStatusToExtension = () => {
-  const connectedPixels = filter(p => p.isConnected, window.pixels || []);
-  const totalPixels = (window.pixels || []).length;
+  const pixels = window.pixels || [];
+
+  // Verify actual GATT state for each pixel, not just cached _isConnected
+  const connectedPixels = filter(p => {
+    try {
+      return p.isConnected && p.device && p.device.gatt && p.device.gatt.connected;
+    } catch {
+      return false;
+    }
+  }, pixels);
+  const totalPixels = pixels.length;
 
   if (totalPixels === 0) {
     sendTextToExtension('No Pixel connected');


### PR DESCRIPTION
- Fix legacy notify UUID (6e400001 → 6e400003) for Nordic UART Service
- Add dual-path reconnection: watchAdvertisements() with automatic fallback to polling for Linux where watchAdvertisements silently fails
- Add getDevices() on init for silent reconnection after page refresh
- Preserve _device reference across disconnections to enable reconnection
- Prevent duplicate gattserverdisconnected listeners via tracking flag
- Fix stale popup status by verifying actual GATT state and polling every 5s
- Add destroy() method for permanent pixel removal (used by 6-hour cleanup)
- Add feature spec in specs/bluetooth-connection-reliability.md