### PR TITLE
feat(profiles): per-profile export + rename bulk export to 'Export All'

### DIFF
--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -279,7 +279,7 @@ body {
 .profile-item {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   background-color: #1a1a1a;
   border: 1px solid #444444;
   border-radius: 4px;
@@ -320,7 +320,7 @@ body {
   color: #ffffff;
   border: 1px solid #555555;
   border-radius: 4px;
-  padding: 5px 10px;
+  padding: 5px 8px;
   font-size: 12px;
   cursor: pointer;
   transition: all 0.2s ease;

--- a/src/components/popup/popup.html
+++ b/src/components/popup/popup.html
@@ -73,7 +73,9 @@
           </div>
 
           <div class="profile-io-row">
-            <button id="exportProfiles" class="secondary-button">Export</button>
+            <button id="exportProfiles" class="secondary-button">
+              Export All
+            </button>
             <button id="importProfiles" class="secondary-button">Import</button>
             <input
               id="importFile"

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -7,6 +7,7 @@ import {
   getActiveProfile,
   setActiveProfile,
   exportProfiles,
+  exportProfile,
   importProfiles,
 } from '../../utils/profileStorage.js';
 
@@ -215,6 +216,12 @@ async function renderProfiles() {
     loadBtn.textContent = 'Load';
     loadBtn.onclick = () => loadProfile(name);
 
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'profile-item-btn export';
+    exportBtn.textContent = 'Export';
+    exportBtn.title = `Export "${name}" to a file`;
+    exportBtn.onclick = () => exportSingleProfile(name);
+
     const deleteBtn = document.createElement('button');
     deleteBtn.className = 'profile-item-btn delete';
     deleteBtn.textContent = 'Delete';
@@ -222,6 +229,7 @@ async function renderProfiles() {
 
     li.appendChild(label);
     li.appendChild(loadBtn);
+    li.appendChild(exportBtn);
     li.appendChild(deleteBtn);
     list.appendChild(li);
   });
@@ -340,6 +348,30 @@ function removeProfile(name) {
     .catch(() => showText('Failed to delete profile.'));
 }
 
+// Trigger a download of a bundle as a JSON file.
+function downloadBundle(bundle, filename) {
+  const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// Make a filesystem-safe slug from a profile name.
+function slugify(name) {
+  return (
+    name
+      .trim()
+      .replace(/[^a-z0-9]+/gi, '-')
+      .replace(/^-+|-+$/g, '')
+      .toLowerCase() || 'profile'
+  );
+}
+
 // Export all profiles to a downloaded JSON file.
 function exportProfilesToFile() {
   exportProfiles()
@@ -348,19 +380,26 @@ function exportProfilesToFile() {
         showText('No profiles to export.');
         return;
       }
-      const blob = new Blob([JSON.stringify(bundle, null, 2)], {
-        type: 'application/json',
-      });
-      const url = URL.createObjectURL(blob);
       const stamp = new Date().toISOString().slice(0, 10);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `pixels-roll20-profiles-${stamp}.json`;
-      a.click();
-      URL.revokeObjectURL(url);
-      showText('Exported profiles.');
+      downloadBundle(bundle, `pixels-roll20-profiles-${stamp}.json`);
+      showText('Exported all profiles.');
     })
     .catch(() => showText('Failed to export profiles.'));
+}
+
+// Export a single profile to a downloaded JSON file.
+function exportSingleProfile(name) {
+  exportProfile(name)
+    .then(bundle => {
+      if (!bundle) {
+        showText('Profile not found.');
+        renderProfiles();
+        return;
+      }
+      downloadBundle(bundle, `pixels-roll20-profile-${slugify(name)}.json`);
+      showText(`Exported profile "${name}".`);
+    })
+    .catch(() => showText('Failed to export profile.'));
 }
 
 // Import profiles from a chosen JSON file, merging (keep-both on name clash).

--- a/src/utils/profileStorage.js
+++ b/src/utils/profileStorage.js
@@ -44,8 +44,8 @@ function hasLastError() {
   try {
     return Boolean(
       typeof chrome !== 'undefined' &&
-        chrome.runtime &&
-        chrome.runtime.lastError
+      chrome.runtime &&
+      chrome.runtime.lastError
     );
   } catch {
     return false;
@@ -181,6 +181,22 @@ async function exportProfiles() {
   };
 }
 
+// Build an export bundle containing a single profile by name. Returns null if
+// the profile does not exist. Same shape as exportProfiles so it imports back
+// identically.
+async function exportProfile(name) {
+  const profiles = await getProfiles();
+  if (!name || !(name in profiles)) {
+    return null;
+  }
+  return {
+    type: EXPORT_TYPE,
+    version: 1,
+    exportedAt: Date.now(),
+    profiles: { [name]: profiles[name] },
+  };
+}
+
 // Return a name not already present in `existingNames` (a Set), appending
 // " (2)", " (3)", ... as needed. Implements the keep-both import strategy.
 function uniqueName(base, existingNames) {
@@ -249,6 +265,7 @@ const ProfileStorage = {
   getActiveProfile,
   setActiveProfile,
   exportProfiles,
+  exportProfile,
   importProfiles,
   // Exposed for tests
   mergeProfiles,
@@ -267,6 +284,7 @@ export {
   getActiveProfile,
   setActiveProfile,
   exportProfiles,
+  exportProfile,
   importProfiles,
   mergeProfiles,
   uniqueName,

--- a/tests/jest/utils/profileStorage.test.js
+++ b/tests/jest/utils/profileStorage.test.js
@@ -200,6 +200,44 @@ describe('profileStorage', () => {
       expect(bundle.profiles.Combat).toBeDefined();
     });
 
+    test('exportProfile returns a bundle with only the named profile', async () => {
+      await profileStorage.saveProfile('Combat', {
+        rows: [{ name: 'Rage', value: '2' }],
+        selectedIndex: 0,
+      });
+      await profileStorage.saveProfile('Social', {
+        rows: [],
+        selectedIndex: -1,
+      });
+
+      const bundle = await profileStorage.exportProfile('Combat');
+
+      expect(bundle.type).toBe('pixels-roll20-profiles');
+      expect(Object.keys(bundle.profiles)).toEqual(['Combat']);
+    });
+
+    test('exportProfile returns null for an unknown profile', async () => {
+      expect(await profileStorage.exportProfile('Nope')).toBeNull();
+    });
+
+    test('a single-profile export imports back identically', async () => {
+      await profileStorage.saveProfile('Combat', {
+        rows: [{ name: 'Rage', value: '2' }],
+        selectedIndex: 0,
+      });
+      const bundle = await profileStorage.exportProfile('Combat');
+
+      // Fresh store
+      local = makeArea();
+      sync = makeArea();
+      chrome.storage = { local, sync };
+
+      const result = await profileStorage.importProfiles(bundle);
+      expect(result.imported).toBe(1);
+      const profiles = await profileStorage.getProfiles();
+      expect(profiles.Combat.rows[0].name).toBe('Rage');
+    });
+
     test('importProfiles keeps both on name collision (rename)', async () => {
       await profileStorage.saveProfile('Combat', {
         rows: [{ name: 'original', value: '0' }],


### PR DESCRIPTION
## What
- Each saved profile row now has its own **Export** button that downloads just that profile (`pixels-roll20-profile-<name>.json`).
- Renamed the section's bulk **Export** button to **Export All**.

## How
- New `profileStorage.exportProfile(name)` builds a single-profile bundle in the **same shape** as `exportProfiles`, so a single-profile file imports back identically (and merges/renames on collision like any other import).
- Refactored the popup's blob-download into a shared `downloadBundle` helper + a `slugify` for filenames.

## Tests / verification
- Added tests for `exportProfile` (single-profile bundle, unknown-name → null, single-export round-trips through import).
- Lint clean · 215 tests passing · webpack build succeeds.