### PR TITLE
feat(modifier-box): auto-select + focus new row on Add

### DIFF
--- a/src/components/modifierBox/rowManager.js
+++ b/src/components/modifierBox/rowManager.js
@@ -106,11 +106,30 @@ function addModifierRow(modifierBox, updateSelectedModifierCallback) {
   content.appendChild(newRow);
   rowCounter++;
 
+  // Auto-select the new row so it becomes the active modifier
+  const newRadio = newRow.querySelector('.modifier-radio');
+  if (newRadio) {
+    newRadio.checked = true;
+  }
+
   // Update event listeners for all rows
   updateEventListeners(modifierBox, updateSelectedModifierCallback);
 
+  // Sync the new selection (setting `checked` programmatically does not fire
+  // the change listener that normally updates the active modifier)
+  if (updateSelectedModifierCallback) {
+    updateSelectedModifierCallback();
+  }
+
   // Save the updated state to localStorage
   saveModifierRows(modifierBox);
+
+  // Move focus to the new row's name field, selecting its text for quick edit
+  const newNameInput = newRow.querySelector('.modifier-name');
+  if (newNameInput) {
+    newNameInput.focus();
+    newNameInput.select();
+  }
 
   // Force theme updates on the new elements
   if (

--- a/tests/jest/components/modifierBox/rowManager.test.js
+++ b/tests/jest/components/modifierBox/rowManager.test.js
@@ -197,6 +197,26 @@ describe('ModifierBox Row Manager', () => {
       expect(removeBtn.textContent).toBe('×');
     });
 
+    test('should auto-select the new row and focus its name field', () => {
+      const content = mockModifierBox.querySelector('.pixels-content');
+
+      window.ModifierBoxRowManager.addModifierRow(
+        mockModifierBox,
+        mockCallback
+      );
+
+      const newRow = content.lastElementChild;
+      const radio = newRow.querySelector('.modifier-radio');
+      const nameInput = newRow.querySelector('.modifier-name');
+
+      // New row becomes the selected/active modifier
+      expect(radio.checked).toBe(true);
+      // Selection change is propagated to the caller
+      expect(mockCallback).toHaveBeenCalled();
+      // Cursor moves to the new row's name field
+      expect(document.activeElement).toBe(nameInput);
+    });
+
     test('should increment row counter', () => {
       const initialCounter = window.ModifierBoxRowManager.getRowCounter();
 


### PR DESCRIPTION
Clicking **Add** in the modifier box now:
- selects the new row (its radio is checked, making it the active modifier),
- propagates the selection through the update callback, and
- moves the cursor to the new row's **name** field with the text selected, so you can immediately type the modifier's name.

Added a test asserting the new row is checked, the callback fires, and the name field receives focus. Lint clean · 213 tests passing · build succeeds.