### PR TITLE
feat: wire Firefox native-messaging path into the extension

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -38,3 +38,64 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true; // Will respond asynchronously
   }
 });
+
+// Firefox native-messaging relay: content scripts (PixelsNativeBridge.js)
+// can't call connectNative() themselves, so the background script opens the
+// native host on their behalf and pipes messages both ways. See
+// native-host/PROTOCOL.md for the message shapes being relayed.
+const NATIVE_HOST_NAME = 'pixels_roll20_helper';
+const NATIVE_PORT_NAME = 'pixels-native';
+
+chrome.runtime.onConnect.addListener(port => {
+  if (port.name !== NATIVE_PORT_NAME) {
+    return;
+  }
+
+  let nativePort;
+  try {
+    nativePort = chrome.runtime.connectNative(NATIVE_HOST_NAME);
+  } catch (error) {
+    console.log(`Failed to connect to native host: ${error.message}`);
+    safePostMessage(port, { event: 'hostMissing' });
+    return;
+  }
+
+  nativePort.onMessage.addListener(message => {
+    safePostMessage(port, message);
+  });
+
+  nativePort.onDisconnect.addListener(() => {
+    // connectNative() doesn't fail synchronously when the host isn't
+    // installed/registered — the browser reports that asynchronously here,
+    // via onDisconnect with lastError set, instead of throwing above.
+    const error = chrome.runtime.lastError;
+    if (error) {
+      console.log(`Native host disconnected: ${error.message}`);
+      safePostMessage(port, { event: 'hostMissing' });
+    }
+  });
+
+  port.onMessage.addListener(message => {
+    try {
+      nativePort.postMessage(message);
+    } catch (error) {
+      console.log(`Failed to forward message to native host: ${error.message}`);
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    try {
+      nativePort.disconnect();
+    } catch {
+      // Already disconnected.
+    }
+  });
+});
+
+function safePostMessage(port, message) {
+  try {
+    port.postMessage(message);
+  } catch {
+    // Content-script port already closed; nothing to relay to.
+  }
+}

--- a/src/content/modules/PixelsNativeBridge.js
+++ b/src/content/modules/PixelsNativeBridge.js
@@ -1,0 +1,274 @@
+/**
+ * PixelsNativeBridge.js
+ *
+ * Firefox connectivity path: Firefox has no Web Bluetooth, so BLE is
+ * handled out-of-process by a native messaging host (see native-host/),
+ * reached through the background script's runtime.connectNative() relay
+ * (see src/background/background.js). Same public surface as
+ * PixelsBluetooth.js — initialize/connectToPixel/disconnectAllPixels/
+ * getPixels/getConnectedPixelsList/findPixelByName, plus the window.*
+ * legacy globals — so roll20.js can pick either implementation based on
+ * navigator.bluetooth feature detection and wire it up identically.
+ *
+ * Unlike Chrome, there is no per-device picker here: the native host
+ * auto-connects to every Pixels die it discovers when asked to scan.
+ */
+
+import { processNotification } from './rollProcessor';
+
+// Utility functions
+const log = window.log || console.log;
+const sendTextToExtension = window.sendTextToExtension || function () {};
+const sendStatusToExtension = window.sendStatusToExtension || function () {};
+
+const NATIVE_PORT_NAME = 'pixels-native';
+
+// Global pixels array — lightweight die objects (name/id/connected/
+// lastFaceUp), not GATT-backed. The actual BLE connection lives in the
+// native host process; this content script only tracks what it's told
+// about via port messages.
+const pixels = [];
+
+let port = null;
+
+const findDieById = id => pixels.find(p => p.deviceId === id);
+
+const bytesToDataView = bytes => new DataView(new Uint8Array(bytes).buffer);
+
+// Die factory — mirrors createPixel() in PixelsBluetooth.js closely enough
+// that the two are interchangeable from the caller's point of view, but
+// carries no GATT/device reference (there is none on this path).
+const createNativeDie = (id, name) => {
+  // hasMoved/face are mutated by rollProcessor (passed by reference) so
+  // face-event state persists across notifications, same as PixelsBluetooth.
+  const _dieState = { hasMoved: false, face: null };
+  let _isConnected = false;
+  let _lastActivity = Date.now();
+
+  const dieAPI = {
+    get name() {
+      return name;
+    },
+    get deviceId() {
+      return id;
+    },
+    get isConnected() {
+      return _isConnected;
+    },
+    get lastActivity() {
+      return _lastActivity;
+    },
+    get lastFaceUp() {
+      return _dieState.face;
+    },
+    // Internal properties for compatibility with PixelsBluetooth's shape
+    get _name() {
+      return name;
+    },
+    get _deviceId() {
+      return id;
+    },
+    get _isConnected() {
+      return _isConnected;
+    },
+    setConnected(connected) {
+      _isConnected = connected;
+      _lastActivity = Date.now();
+    },
+    handleNotification(dataView) {
+      _lastActivity = Date.now();
+      try {
+        processNotification(name, _dieState, dataView);
+      } catch (error) {
+        log(`Notification handling error for ${name}: ${error.message}`);
+      }
+    },
+    // No per-die disconnect command exists in the native protocol (only a
+    // bulk "disconnect all") — this just updates local state so stale UI
+    // doesn't show a die as connected after disconnectAllPixels().
+    disconnect() {
+      _isConnected = false;
+    },
+  };
+
+  return dieAPI;
+};
+
+const handleHostMessage = message => {
+  if (!message || typeof message !== 'object') {
+    return;
+  }
+
+  switch (message.event) {
+    case 'dieConnected': {
+      let die = findDieById(message.id);
+      if (!die) {
+        die = createNativeDie(message.id, message.name);
+        pixels.push(die);
+      }
+      die.setConnected(true);
+      log(`Pixel ${message.name} connected`);
+      sendTextToExtension(`Connected to ${message.name}`);
+      sendStatusToExtension();
+      break;
+    }
+
+    case 'dieDisconnected': {
+      const die = findDieById(message.id);
+      if (die) {
+        die.setConnected(false);
+      }
+      log(`Pixel ${message.name} disconnected`);
+      sendStatusToExtension();
+      break;
+    }
+
+    case 'notification': {
+      const die = findDieById(message.id);
+      if (die) {
+        die.handleNotification(bytesToDataView(message.data));
+      }
+      break;
+    }
+
+    case 'scanDone':
+      log(`Native scan complete, ${message.found} die/dice tracked`);
+      break;
+
+    case 'error':
+      log(`Native host error: ${message.message}`);
+      break;
+
+    case 'hostMissing':
+      sendTextToExtension(
+        'Companion app not installed — see setup instructions'
+      );
+      break;
+
+    case 'status':
+      // Reserved for future popup status rendering; connection state is
+      // already driven by dieConnected/dieDisconnected above.
+      break;
+
+    default:
+      log(`Unknown native bridge event: ${message.event}`);
+  }
+};
+
+// Opens (or returns the already-open) port to the background script's
+// native-messaging relay. Throws if extension messaging isn't available at
+// all (e.g. running outside an extension context).
+const ensurePort = () => {
+  if (port) {
+    return port;
+  }
+
+  if (
+    typeof chrome === 'undefined' ||
+    !chrome.runtime ||
+    !chrome.runtime.connect
+  ) {
+    throw new Error('Extension messaging is not available');
+  }
+
+  port = chrome.runtime.connect({ name: NATIVE_PORT_NAME });
+
+  port.onMessage.addListener(handleHostMessage);
+  port.onDisconnect.addListener(() => {
+    log('Native bridge port disconnected');
+    port = null;
+    // The relay (or the native host behind it) is gone — reflect that
+    // instead of leaving stale "connected" state in the UI.
+    pixels.forEach(die => die.setConnected(false));
+    sendStatusToExtension();
+  });
+
+  return port;
+};
+
+export const connectToPixel = async () => {
+  try {
+    ensurePort().postMessage({ cmd: 'connect' });
+  } catch (error) {
+    log(`Native connect failed: ${error.message}`);
+    throw error;
+  }
+};
+
+export const disconnectAllPixels = () => {
+  try {
+    ensurePort().postMessage({ cmd: 'disconnect' });
+  } catch (error) {
+    log(`Native disconnect failed: ${error.message}`);
+  }
+
+  const count = pixels.length;
+  pixels.forEach(die => die.disconnect());
+  pixels.length = 0;
+
+  log(`Disconnected ${count} pixels`);
+  sendTextToExtension(`Disconnected ${count} pixels`);
+  sendStatusToExtension();
+};
+
+export const getPixels = () => pixels;
+
+export const getConnectedPixelsList = () => pixels.filter(p => p.isConnected);
+
+export const findPixelByName = name => pixels.find(p => p.name === name);
+
+export const initialize = () => {
+  log('PixelsNativeBridge module initialized');
+  window.pixels = pixels;
+
+  try {
+    ensurePort();
+  } catch (error) {
+    log(`Failed to open native bridge port: ${error.message}`);
+  }
+
+  return {
+    connectToPixel,
+    disconnectAllPixels,
+    getPixels,
+    getConnectedPixelsList,
+    findPixelByName,
+  };
+};
+
+// Default export for convenience
+export default {
+  connectToPixel,
+  disconnectAllPixels,
+  getPixels,
+  getConnectedPixelsList,
+  findPixelByName,
+  initialize,
+  createNativeDie,
+};
+
+// Legacy global exports for compatibility (when not using modules)
+if (typeof window !== 'undefined') {
+  window.PixelsNativeBridge = {
+    connectToPixel,
+    disconnectAllPixels,
+    getPixels,
+    initialize,
+    createNativeDie,
+  };
+
+  window.connectToPixel = connectToPixel;
+  window.pixels = pixels;
+}
+
+// Expose for testing
+if (typeof global !== 'undefined') {
+  global.createNativeDie = createNativeDie;
+  global.PixelsNativeBridge = {
+    connectToPixel,
+    disconnectAllPixels,
+    getPixels,
+    initialize,
+    createNativeDie,
+  };
+}

--- a/src/content/roll20.js
+++ b/src/content/roll20.js
@@ -7,10 +7,16 @@
 
 import {
   initialize as initializePixelsBluetooth,
-  connectToPixel,
-  disconnectAllPixels,
-  getPixels,
+  connectToPixel as connectToPixelBluetooth,
+  disconnectAllPixels as disconnectAllPixelsBluetooth,
+  getPixels as getPixelsBluetooth,
 } from './modules/PixelsBluetooth.js';
+import {
+  initialize as initializePixelsNativeBridge,
+  connectToPixel as connectToPixelNative,
+  disconnectAllPixels as disconnectAllPixelsNative,
+  getPixels as getPixelsNative,
+} from './modules/PixelsNativeBridge.js';
 import {
   sendTextToExtension,
   sendStatusToExtension,
@@ -30,8 +36,24 @@ if (typeof window.roll20PixelsLoaded === 'undefined') {
 
     log('Starting Pixels Roll20 extension');
 
-    // Initialize the Bluetooth module
-    initializePixelsBluetooth();
+    // Feature-detect: Chrome/Edge implement Web Bluetooth; Firefox does
+    // not, so it goes through the native-messaging bridge instead (see
+    // native-host/ and specs/firefox-native-messaging-support.md).
+    const useNativeBridge = !navigator.bluetooth;
+
+    let connectToPixel, disconnectAllPixels, getPixels;
+    if (useNativeBridge) {
+      log('navigator.bluetooth unavailable, using native messaging bridge');
+      initializePixelsNativeBridge();
+      connectToPixel = connectToPixelNative;
+      disconnectAllPixels = disconnectAllPixelsNative;
+      getPixels = getPixelsNative;
+    } else {
+      initializePixelsBluetooth();
+      connectToPixel = connectToPixelBluetooth;
+      disconnectAllPixels = disconnectAllPixelsBluetooth;
+      getPixels = getPixelsBluetooth;
+    }
 
     // Expose functions to global scope for backwards compatibility
     window.connectToPixel = connectToPixel;

--- a/src/core/extensionMessaging.js
+++ b/src/core/extensionMessaging.js
@@ -35,10 +35,21 @@ export const sendTextToExtension = txt => {
 export const sendStatusToExtension = () => {
   const pixels = window.pixels || [];
 
-  // Verify actual GATT state for each pixel, not just cached _isConnected
+  // GATT-backed pixels (Chrome/Web Bluetooth, PixelsBluetooth.js) can have
+  // a stale cached _isConnected flag, so also verify the live GATT state.
+  // Native-bridge pixels (Firefox, PixelsNativeBridge.js) have no
+  // device/gatt object at all — the real connection lives in the native
+  // host process — so isConnected is authoritative there; duck-type on
+  // whether a device/gatt is present rather than assuming one exists.
   const connectedPixels = filter(p => {
     try {
-      return p.isConnected && p.device && p.device.gatt && p.device.gatt.connected;
+      if (!p.isConnected) {
+        return false;
+      }
+      if (p.device && p.device.gatt) {
+        return p.device.gatt.connected;
+      }
+      return true;
     } catch {
       return false;
     }

--- a/tests/jest/backgroundNativeRelay.test.js
+++ b/tests/jest/backgroundNativeRelay.test.js
@@ -1,0 +1,162 @@
+/**
+ * Tests for the native-messaging relay in background.js. Content scripts
+ * can't call chrome.runtime.connectNative() themselves — only the
+ * background script can — so this pipes a runtime.connect port named
+ * 'pixels-native' (opened by PixelsNativeBridge.js) to a
+ * connectNative('pixels_roll20_helper') connection and back. See
+ * native-host/PROTOCOL.md for the message shapes being relayed.
+ */
+
+const BACKGROUND_PATH = '../../src/background/background.js';
+
+const makeMockPort = name => ({
+  name,
+  postMessage: jest.fn(),
+  disconnect: jest.fn(),
+  onMessage: { addListener: jest.fn() },
+  onDisconnect: { addListener: jest.fn() },
+});
+
+describe('background.js native messaging relay', () => {
+  let contentPort;
+  let nativePort;
+  let onConnectListener;
+  let connectNative;
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    contentPort = makeMockPort('pixels-native');
+    nativePort = makeMockPort('native');
+    connectNative = jest.fn(() => nativePort);
+
+    global.chrome = {
+      runtime: {
+        onInstalled: { addListener: jest.fn() },
+        onMessage: { addListener: jest.fn() },
+        onConnect: {
+          addListener: jest.fn(listener => {
+            onConnectListener = listener;
+          }),
+        },
+        connectNative,
+        lastError: undefined,
+      },
+      storage: {
+        sync: {
+          get: jest.fn((keys, cb) => cb({})),
+          set: jest.fn((data, cb) => cb && cb()),
+        },
+      },
+    };
+
+    require(BACKGROUND_PATH);
+  });
+
+  test('ignores connections on unrelated port names', () => {
+    const otherPort = makeMockPort('something-else');
+    onConnectListener(otherPort);
+    expect(connectNative).not.toHaveBeenCalled();
+  });
+
+  test('opens the native host by name for a pixels-native port', () => {
+    onConnectListener(contentPort);
+    expect(connectNative).toHaveBeenCalledWith('pixels_roll20_helper');
+  });
+
+  test('relays native host messages to the content port unchanged', () => {
+    onConnectListener(contentPort);
+    const nativeMessageHandler =
+      nativePort.onMessage.addListener.mock.calls[0][0];
+
+    nativeMessageHandler({ event: 'dieConnected', id: 'abc', name: 'Aurora' });
+
+    expect(contentPort.postMessage).toHaveBeenCalledWith({
+      event: 'dieConnected',
+      id: 'abc',
+      name: 'Aurora',
+    });
+  });
+
+  test('relays content-port messages to the native host unchanged', () => {
+    onConnectListener(contentPort);
+    const contentMessageHandler =
+      contentPort.onMessage.addListener.mock.calls[0][0];
+
+    contentMessageHandler({ cmd: 'connect' });
+
+    expect(nativePort.postMessage).toHaveBeenCalledWith({ cmd: 'connect' });
+  });
+
+  test('disconnects the native port when the content port closes', () => {
+    onConnectListener(contentPort);
+    const contentDisconnectHandler =
+      contentPort.onDisconnect.addListener.mock.calls[0][0];
+
+    contentDisconnectHandler();
+
+    expect(nativePort.disconnect).toHaveBeenCalled();
+  });
+
+  test('reports hostMissing if connectNative throws synchronously', () => {
+    connectNative.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    onConnectListener(contentPort);
+
+    expect(contentPort.postMessage).toHaveBeenCalledWith({
+      event: 'hostMissing',
+    });
+  });
+
+  test('does not attach native port listeners after a synchronous connectNative failure', () => {
+    connectNative.mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    expect(() => onConnectListener(contentPort)).not.toThrow();
+    expect(nativePort.onMessage.addListener).not.toHaveBeenCalled();
+  });
+
+  test('reports hostMissing if the native host disconnects immediately with lastError set', () => {
+    onConnectListener(contentPort);
+    const nativeDisconnectHandler =
+      nativePort.onDisconnect.addListener.mock.calls[0][0];
+
+    global.chrome.runtime.lastError = {
+      message: 'Specified native messaging host not found.',
+    };
+    nativeDisconnectHandler();
+
+    expect(contentPort.postMessage).toHaveBeenCalledWith({
+      event: 'hostMissing',
+    });
+  });
+
+  test('does not report hostMissing on a clean native disconnect (no lastError)', () => {
+    onConnectListener(contentPort);
+    const nativeDisconnectHandler =
+      nativePort.onDisconnect.addListener.mock.calls[0][0];
+
+    global.chrome.runtime.lastError = undefined;
+    nativeDisconnectHandler();
+
+    expect(contentPort.postMessage).not.toHaveBeenCalledWith({
+      event: 'hostMissing',
+    });
+  });
+
+  test('does not throw if the content port is already closed when relaying', () => {
+    onConnectListener(contentPort);
+    const nativeMessageHandler =
+      nativePort.onMessage.addListener.mock.calls[0][0];
+    contentPort.postMessage.mockImplementation(() => {
+      throw new Error('port closed');
+    });
+
+    expect(() =>
+      nativeMessageHandler({ event: 'scanDone', found: 0 })
+    ).not.toThrow();
+  });
+});

--- a/tests/jest/extensionMessaging.test.js
+++ b/tests/jest/extensionMessaging.test.js
@@ -1,0 +1,86 @@
+/**
+ * Tests for sendStatusToExtension()'s connected-pixel counting, focused on
+ * the duck-typed GATT check: GATT-backed pixels (Chrome/Web Bluetooth,
+ * PixelsBluetooth.js) must still have their live device.gatt.connected
+ * state verified (not just the cached isConnected flag), while
+ * native-bridge pixels (Firefox, PixelsNativeBridge.js) have no
+ * device/gatt object at all and must be trusted on isConnected alone.
+ */
+
+const EXTENSION_MESSAGING_PATH = '../../src/core/extensionMessaging.js';
+
+describe('sendStatusToExtension', () => {
+  let extensionMessaging;
+  let sendMessage;
+
+  const gattPixel = (isConnected, gattConnected) => ({
+    isConnected,
+    device: { gatt: { connected: gattConnected } },
+  });
+
+  const nativePixel = isConnected => ({ isConnected });
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    sendMessage = jest.fn();
+    window.chrome = { runtime: { sendMessage } };
+
+    extensionMessaging = require(EXTENSION_MESSAGING_PATH);
+  });
+
+  const lastText = () => sendMessage.mock.calls.at(-1)[0].text;
+
+  test('reports no pixels when window.pixels is empty', () => {
+    window.pixels = [];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('No Pixel connected');
+  });
+
+  test('reports connected for a single GATT pixel with live gatt.connected true', () => {
+    window.pixels = [gattPixel(true, true)];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('1 Pixel connected');
+  });
+
+  test('reports disconnected for a GATT pixel with a stale isConnected flag but dead GATT', () => {
+    // isConnected is cached and can lag reality; live gatt.connected must win.
+    window.pixels = [gattPixel(true, false)];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('1 Pixel disconnected');
+  });
+
+  test('reports connected for a single native-bridge pixel with no device/gatt', () => {
+    window.pixels = [nativePixel(true)];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('1 Pixel connected');
+  });
+
+  test('reports disconnected for a native-bridge pixel with isConnected false', () => {
+    window.pixels = [nativePixel(false)];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('1 Pixel disconnected');
+  });
+
+  test('counts a mix of GATT and native-bridge pixels correctly', () => {
+    window.pixels = [
+      gattPixel(true, true), // connected
+      gattPixel(true, false), // stale flag, actually disconnected
+      nativePixel(true), // connected
+      nativePixel(false), // disconnected
+    ];
+    extensionMessaging.sendStatusToExtension();
+    expect(lastText()).toBe('2/4 Pixels connected');
+  });
+
+  test('excludes a pixel whose isConnected getter throws, without failing the rest', () => {
+    const throwingPixel = {
+      get isConnected() {
+        throw new Error('boom');
+      },
+    };
+    window.pixels = [throwingPixel, nativePixel(true)];
+    expect(() => extensionMessaging.sendStatusToExtension()).not.toThrow();
+    expect(lastText()).toBe('1/2 Pixels connected');
+  });
+});

--- a/tests/jest/pixelsNativeBridge.test.js
+++ b/tests/jest/pixelsNativeBridge.test.js
@@ -1,0 +1,266 @@
+/**
+ * Tests for PixelsNativeBridge.js — the Firefox connectivity path that
+ * talks to the native messaging host through a background-script relay
+ * instead of Web Bluetooth. Covers the port lifecycle, host-event handling,
+ * and (via the real rollProcessor) that a roll actually updates state and
+ * posts to chat, same as pixelsBluetoothNotifications.test.js does for the
+ * Chrome path.
+ */
+
+const NATIVE_BRIDGE_PATH = '../../src/content/modules/PixelsNativeBridge.js';
+
+const makeMockPort = () => ({
+  postMessage: jest.fn(),
+  onMessage: { addListener: jest.fn() },
+  onDisconnect: { addListener: jest.fn() },
+});
+
+describe('PixelsNativeBridge', () => {
+  let bridge;
+  let mockPort;
+  let sendTextToExtension;
+  let sendStatusToExtension;
+  let postChatMessage;
+
+  const hostMessageListener = () =>
+    mockPort.onMessage.addListener.mock.calls[0][0];
+  const portDisconnectListener = () =>
+    mockPort.onDisconnect.addListener.mock.calls[0][0];
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    mockPort = makeMockPort();
+    window.chrome = {
+      runtime: {
+        connect: jest.fn(() => mockPort),
+      },
+    };
+
+    sendTextToExtension = jest.fn();
+    sendStatusToExtension = jest.fn();
+    postChatMessage = jest.fn();
+    window.sendTextToExtension = sendTextToExtension;
+    window.sendStatusToExtension = sendStatusToExtension;
+    window.postChatMessage = postChatMessage;
+    window.log = jest.fn();
+    window.pixelsModifierName = 'Modifier 1';
+    window.pixelsModifier = '0';
+    delete window.ModifierBox;
+
+    bridge = require(NATIVE_BRIDGE_PATH);
+  });
+
+  describe('initialize', () => {
+    test('opens a port named pixels-native', () => {
+      bridge.initialize();
+      expect(window.chrome.runtime.connect).toHaveBeenCalledWith({
+        name: 'pixels-native',
+      });
+    });
+
+    test('does not throw when extension messaging is unavailable', () => {
+      window.chrome = {};
+      expect(() => bridge.initialize()).not.toThrow();
+    });
+  });
+
+  describe('connectToPixel', () => {
+    test('sends a connect command over the port', async () => {
+      bridge.initialize();
+      await bridge.connectToPixel();
+      expect(mockPort.postMessage).toHaveBeenCalledWith({ cmd: 'connect' });
+    });
+
+    test('rejects when extension messaging is unavailable', async () => {
+      window.chrome = {};
+      await expect(bridge.connectToPixel()).rejects.toThrow();
+    });
+  });
+
+  describe('host events', () => {
+    beforeEach(() => {
+      bridge.initialize();
+    });
+
+    test('dieConnected adds a new die and marks it connected', () => {
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      const pixels = bridge.getPixels();
+      expect(pixels).toHaveLength(1);
+      expect(pixels[0].name).toBe('Aurora');
+      expect(pixels[0].isConnected).toBe(true);
+      expect(sendTextToExtension).toHaveBeenCalledWith('Connected to Aurora');
+      expect(sendStatusToExtension).toHaveBeenCalled();
+    });
+
+    test('dieConnected for an already-tracked id updates it in place, not a duplicate', () => {
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+      hostMessageListener()({
+        event: 'dieDisconnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      expect(bridge.getPixels()).toHaveLength(1);
+      expect(bridge.getPixels()[0].isConnected).toBe(true);
+    });
+
+    test('dieDisconnected marks a tracked die disconnected without removing it', () => {
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+      hostMessageListener()({
+        event: 'dieDisconnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      const pixels = bridge.getPixels();
+      expect(pixels).toHaveLength(1);
+      expect(pixels[0].isConnected).toBe(false);
+    });
+
+    test('notification for an unknown id is ignored without throwing', () => {
+      expect(() =>
+        hostMessageListener()({
+          event: 'notification',
+          id: 'unknown',
+          name: 'Ghost',
+          data: [3, 1, 5],
+        })
+      ).not.toThrow();
+      expect(postChatMessage).not.toHaveBeenCalled();
+    });
+
+    test('a full roll (movement then rest) updates lastFaceUp and posts to chat', () => {
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      hostMessageListener()({
+        event: 'notification',
+        id: 'abc',
+        name: 'Aurora',
+        data: [3, 2, 0], // moving
+      });
+      expect(bridge.getPixels()[0].lastFaceUp).toBeNull();
+
+      hostMessageListener()({
+        event: 'notification',
+        id: 'abc',
+        name: 'Aurora',
+        data: [3, 1, 5], // settled, face byte 5
+      });
+
+      expect(bridge.getPixels()[0].lastFaceUp).toBe(5);
+      expect(postChatMessage).toHaveBeenCalledTimes(1);
+      expect(postChatMessage.mock.calls[0][0]).toContain('Pixel Roll');
+    });
+
+    test('hostMissing surfaces a status message', () => {
+      hostMessageListener()({ event: 'hostMissing' });
+      expect(sendTextToExtension).toHaveBeenCalledWith(
+        expect.stringContaining('Companion app not installed')
+      );
+    });
+
+    test('ignores malformed messages without throwing', () => {
+      expect(() => hostMessageListener()(null)).not.toThrow();
+      expect(() => hostMessageListener()('not an object')).not.toThrow();
+      expect(() =>
+        hostMessageListener()({ event: 'somethingUnknown' })
+      ).not.toThrow();
+    });
+  });
+
+  describe('port disconnect', () => {
+    test('marks all tracked dice disconnected and updates status', () => {
+      bridge.initialize();
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      portDisconnectListener()();
+
+      expect(bridge.getPixels()[0].isConnected).toBe(false);
+      expect(sendStatusToExtension).toHaveBeenCalled();
+    });
+
+    test('a later connectToPixel re-opens the port', async () => {
+      bridge.initialize();
+      portDisconnectListener()();
+
+      await bridge.connectToPixel();
+
+      expect(window.chrome.runtime.connect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('disconnectAllPixels', () => {
+    test('sends a disconnect command, clears local state, and updates status', () => {
+      bridge.initialize();
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      bridge.disconnectAllPixels();
+
+      expect(mockPort.postMessage).toHaveBeenCalledWith({ cmd: 'disconnect' });
+      expect(bridge.getPixels()).toHaveLength(0);
+      expect(sendStatusToExtension).toHaveBeenCalled();
+    });
+  });
+
+  describe('getConnectedPixelsList', () => {
+    test('filters to only connected dice', () => {
+      bridge.initialize();
+      hostMessageListener()({ event: 'dieConnected', id: 'a', name: 'Aurora' });
+      hostMessageListener()({ event: 'dieConnected', id: 'b', name: 'Nova' });
+      hostMessageListener()({
+        event: 'dieDisconnected',
+        id: 'b',
+        name: 'Nova',
+      });
+
+      const connected = bridge.getConnectedPixelsList();
+      expect(connected).toHaveLength(1);
+      expect(connected[0].name).toBe('Aurora');
+    });
+  });
+
+  describe('findPixelByName', () => {
+    test('finds a tracked die by name', () => {
+      bridge.initialize();
+      hostMessageListener()({
+        event: 'dieConnected',
+        id: 'abc',
+        name: 'Aurora',
+      });
+
+      expect(bridge.findPixelByName('Aurora').deviceId).toBe('abc');
+      expect(bridge.findPixelByName('Nonexistent')).toBeUndefined();
+    });
+  });
+});

--- a/tests/jest/roll20.test.js
+++ b/tests/jest/roll20.test.js
@@ -59,9 +59,11 @@ describe('Roll20.js - Comprehensive Tests', () => {
 
     // Set global mocks
     global.chrome = mockChrome;
-    global.navigator = {
-      bluetooth: mockBluetooth,
-    };
+    // jsdom's `navigator` is a getter-only binding on window, so a whole-
+    // object reassignment (`global.navigator = {...}`) silently no-ops in
+    // non-strict mode. Mutate the existing navigator's `bluetooth` property
+    // instead, same as the "missing Bluetooth API" test further down does.
+    global.navigator.bluetooth = mockBluetooth;
 
     // Mock DOM with proper jest functions
     global.document = {

--- a/tests/jest/setup.js
+++ b/tests/jest/setup.js
@@ -104,12 +104,13 @@ global.simulateEvent = (element, eventType, eventData = {}) => {
 };
 
 // Mock Bluetooth API
-global.navigator = {
-  ...global.navigator,
-  bluetooth: {
-    requestDevice: jest.fn(),
-    getAvailability: jest.fn(() => Promise.resolve(true)),
-  },
+// jsdom's `navigator` is a getter-only binding on window, so a whole-object
+// reassignment (`global.navigator = {...}`) silently no-ops in non-strict
+// mode, leaving the real jsdom navigator (no .bluetooth) in place. Mutate
+// the existing navigator instead so this mock actually takes effect.
+global.navigator.bluetooth = {
+  requestDevice: jest.fn(),
+  getAvailability: jest.fn(() => Promise.resolve(true)),
 };
 
 // Run before each test

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -55,6 +55,8 @@ const config = {
       './src/content/modules/ModifierBoxManager.js',
     'content/modules/PixelsBluetooth':
       './src/content/modules/PixelsBluetooth.js',
+    'content/modules/PixelsNativeBridge':
+      './src/content/modules/PixelsNativeBridge.js',
 
     // Modifier box components
     'components/modifierBox/modifierBox':

--- a/webpack.firefox.js
+++ b/webpack.firefox.js
@@ -37,6 +37,20 @@ module.exports = {
               gecko: { id: FIREFOX_EXTENSION_ID },
             };
 
+            // Firefox has no Web Bluetooth — swap the Chrome-only
+            // GATT-based module for the native-messaging bridge. (roll20.js
+            // itself still feature-detects and picks the right one at
+            // runtime; this only controls which module's standalone script
+            // — and thus its early window.* legacy exports — loads first.)
+            manifest.content_scripts.forEach(entry => {
+              const index = entry.js.indexOf(
+                'content/modules/PixelsBluetooth.js'
+              );
+              if (index !== -1) {
+                entry.js[index] = 'content/modules/PixelsNativeBridge.js';
+              }
+            });
+
             return JSON.stringify(manifest, null, 2);
           },
         },


### PR DESCRIPTION
## Summary
Implements Milestone 4 of `specs/firefox-native-messaging-support.md` — the piece that actually wires Firefox up end-to-end, tying together the native host (#15), `rollProcessor` (#16), and the dual-browser build (#17).

- **New `src/content/modules/PixelsNativeBridge.js`**: same public surface as `PixelsBluetooth.js` (`initialize`/`connectToPixel`/`disconnectAllPixels`/`getPixels`/`getConnectedPixelsList`/`findPixelByName` + `window.*` legacy globals). Opens a `runtime.connect({name:'pixels-native'})` port, sends `connect`/`disconnect` commands, and feeds notification bytes into the shared `rollProcessor`. Dice are lightweight objects with no `device`/`gatt` — the real BLE connection lives in the native host process.
- **`src/background/background.js`**: relays that port to `runtime.connectNative('pixels_roll20_helper')` and back, tears down the native port when the content port closes, and replies `{event:"hostMissing"}` if the host isn't installed/registered (handles both the synchronous-throw and the more common async-`lastError`-on-disconnect failure modes).
- **`src/content/roll20.js`**: `initializeExtension()` now feature-detects `navigator.bluetooth` and wires `window.connectToPixel`/`disconnectAllPixels`/`getPixels` to whichever implementation applies, so `extensionMessaging.js` and the popup's connect/disconnect actions work unchanged either way.
- **`src/core/extensionMessaging.js`**: `sendStatusToExtension()`'s connected-pixel check now duck-types on `device`/`gatt` presence instead of assuming every pixel is GATT-backed (native-bridge pixels have neither).
- **`webpack.common.js`/`webpack.firefox.js`**: `PixelsNativeBridge` added as its own entry; Firefox's manifest `content_scripts` swaps in `PixelsNativeBridge.js` in place of `PixelsBluetooth.js`.

### Bonus fix
Writing tests for this surfaced a real, pre-existing latent bug: jsdom's `navigator` is a getter-only binding on `window`, so `global.navigator = {...}` silently no-ops in non-strict mode. Both `tests/jest/setup.js` and `roll20.test.js` were doing exactly that to mock `navigator.bluetooth` — it never actually took effect, harmlessly, because nothing previously read `navigator.bluetooth` early enough for it to matter. My new feature-detect in `roll20.js` is the first code to do so, which is what surfaced it. Fixed both to mutate the existing `navigator` object instead.

## Test plan
- [x] New tests: `pixelsNativeBridge.test.js` (16 cases — port lifecycle, host-event handling, a full roll through the real `rollProcessor`), `backgroundNativeRelay.test.js` (10 — relay both directions, hostMissing on both failure modes, teardown), `extensionMessaging.test.js` (7 — the duck-typed GATT check directly, including a mixed GATT/native-bridge pixel array)
- [x] `npm test` — 270/270 passing; `npm run lint` clean
- [x] `npm run build` — both `dist/chrome/` and `dist/firefox/` build cleanly; verified Firefox's `content_scripts` array contains `PixelsNativeBridge.js` in place of `PixelsBluetooth.js`, Chrome's is unchanged
- [ ] End-to-end through real Firefox + `runtime.connectNative()` (needs Milestone 5's host registration/install script first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
