### PR TITLE
feat: add Firefox native-messaging host registration + setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This project was originally inspired by the [Pixels on Roll20](https://github.co
 
 **Alternative**: Build from source - see **[Installation Guide](docs/INSTALLATION.md)**.
 
+**Using Firefox?** Web Bluetooth isn't available there, so dice connectivity
+goes through a small native companion app instead — see
+**[Firefox Setup (Beta)](docs/FIREFOX_SETUP.md)**.
+
 ## Building from Source
 
 ```bash

--- a/docs/FIREFOX_SETUP.md
+++ b/docs/FIREFOX_SETUP.md
@@ -1,0 +1,89 @@
+# Firefox Setup (Beta)
+
+Firefox doesn't implement Web Bluetooth (Mozilla classifies it as
+"harmful"), so this extension talks to Pixels dice on Firefox through a
+small companion program instead — a **native messaging host** that Firefox
+launches on demand and that does the actual Bluetooth work. See
+[`../specs/firefox-native-messaging-support.md`](../specs/firefox-native-messaging-support.md)
+for the full design; this page is just the steps to get it running.
+
+**Status:** Windows only, unsigned/temporary add-on only for now. Signed
+installers and a smoother onboarding flow are explicitly deferred — see
+[Known limitations](#known-limitations) below.
+
+## Prerequisites
+
+- Firefox on Windows
+- [Rust](https://rustup.rs/) (stable, MSVC toolchain) and the Visual Studio
+  Build Tools "Desktop development with C++" workload (provides the MSVC
+  linker `link.exe` — Rust needs it to produce a Windows binary)
+- Node.js + npm (to build the extension itself, same as the Chrome build)
+
+## 1. Build the native messaging host
+
+```powershell
+cd native-host
+cargo build --release --target x86_64-pc-windows-msvc
+```
+
+This produces
+`native-host\target\x86_64-pc-windows-msvc\release\pixels-roll20-helper.exe`,
+a single statically-linked binary. See
+[`../native-host/README.md`](../native-host/README.md) for details,
+including a `--cli` mode to sanity-check BLE connectivity without a
+browser at all.
+
+## 2. Register it with Firefox
+
+```powershell
+.\scripts\install-host.ps1
+```
+
+This copies the exe to `%LOCALAPPDATA%\PixelsRoll20\`, writes a native
+messaging host manifest next to it, and points Firefox at that manifest via
+the `HKCU\Software\Mozilla\NativeMessagingHosts\pixels_roll20_helper`
+registry key. Safe to re-run any time (e.g. after rebuilding the exe).
+
+To remove it later: `.\scripts\uninstall-host.ps1`.
+
+## 3. Build and load the extension
+
+```powershell
+npm install
+npm run build:firefox
+```
+
+Then in Firefox:
+
+1. Open `about:debugging#/runtime/this-firefox`
+2. Click **Load Temporary Add-on...**
+3. Select `dist\firefox\manifest.json`
+
+Temporary add-ons are removed when Firefox restarts, so you'll need to
+reload it each session until this is published as a signed release.
+
+## 4. Connect a die
+
+Open a Roll20 game, click the extension icon, and click **Connect**.
+Unlike Chrome's device picker, this auto-connects to _every_ Pixels die
+currently in range — wake a die (roll it gently) if it isn't showing up.
+Roll it, and the result should post to Roll20 chat exactly like the Chrome
+path.
+
+If you see "Companion app not installed" in the popup, the native host
+isn't registered (or isn't reachable) — re-run
+`.\scripts\install-host.ps1` and check `about:debugging` → **This
+Firefox** → your add-on → **Inspect** for background-script console errors.
+
+## Known limitations
+
+- **Windows only.** btleplug supports macOS/Linux too, but the install
+  script and this doc are Windows-specific for now.
+- **No signed installer.** You build and register the host yourself; there's
+  no MSI/pkg or one-click setup yet.
+- **Temporary add-on only.** Not signed for permanent installation or
+  listed on addons.mozilla.org.
+- **No device picker.** The native host auto-connects to every discovered
+  Pixels die — there's no per-device chooser dialog like Web Bluetooth's.
+- **Minimal "host missing" UX.** If the companion app isn't installed, the
+  extension shows a single status line, not a guided setup flow.

--- a/native-host/README.md
+++ b/native-host/README.md
@@ -7,13 +7,14 @@ characteristic — it never writes to a die, and never parses roll data; it
 forwards raw notification bytes and the extension does the rest with the
 same logic used on the Chrome/Web Bluetooth path.
 
-See [`PROTOCOL.md`](./PROTOCOL.md) for the stdin/stdout message format.
+See [`PROTOCOL.md`](./PROTOCOL.md) for the stdin/stdout message format, and
+[`../docs/FIREFOX_SETUP.md`](../docs/FIREFOX_SETUP.md) for the full
+build-and-install walkthrough for using this with Firefox.
 
 This crate implements Milestone 3 of
-[`../specs/firefox-native-messaging-support.md`](../specs/firefox-native-messaging-support.md).
-Host registration (native messaging manifest + install script) and the
-extension-side wiring (background script relay, `PixelsNativeBridge.js`)
-are separate, later milestones in that plan and are not part of this crate.
+[`../specs/firefox-native-messaging-support.md`](../specs/firefox-native-messaging-support.md);
+host registration (`manifests/pixels_roll20_helper.json`,
+`scripts/install-host.ps1`/`uninstall-host.ps1`) is Milestone 5.
 
 ## Build
 
@@ -47,6 +48,10 @@ before exiting).
 Run with no arguments. It expects to be launched by the browser via
 `runtime.connectNative()`, which pipes the extension's messages to its
 stdin and reads its stdout — it is not meant to be run interactively in
-this mode. Host registration (the manifest that tells Firefox this binary
-exists and which extension may launch it, plus the Windows registry key)
-is out of scope for this crate — see Milestone 5 of the plan.
+this mode. `../scripts/install-host.ps1` registers it: it copies the built
+exe to `%LOCALAPPDATA%\PixelsRoll20\`, writes a resolved copy of
+`manifests/pixels_roll20_helper.json` next to it (with `path` pointing at
+the installed exe), and points Firefox at that manifest via the
+`HKCU\Software\Mozilla\NativeMessagingHosts\pixels_roll20_helper` registry
+key. Run `../scripts/uninstall-host.ps1` to remove all of that again. See
+[`../docs/FIREFOX_SETUP.md`](../docs/FIREFOX_SETUP.md) for the full flow.

--- a/native-host/manifests/pixels_roll20_helper.json
+++ b/native-host/manifests/pixels_roll20_helper.json
@@ -1,0 +1,7 @@
+{
+  "name": "pixels_roll20_helper",
+  "description": "Native messaging host bridging Pixels dice Bluetooth notifications to the Pixels Roll20 Firefox extension.",
+  "path": "<install path>",
+  "type": "stdio",
+  "allowed_extensions": ["pixels-roll20@jtoddy.github.io"]
+}

--- a/scripts/install-host.ps1
+++ b/scripts/install-host.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Registers the pixels-roll20-helper native messaging host for Firefox on Windows.
+
+.DESCRIPTION
+    Copies the built pixels-roll20-helper.exe to %LOCALAPPDATA%\PixelsRoll20\,
+    writes a resolved native messaging host manifest next to it (from the
+    template in native-host\manifests\), and points Firefox at that manifest
+    via the HKCU\Software\Mozilla\NativeMessagingHosts registry key.
+
+    Safe to re-run — each run overwrites its own prior install. Run
+    uninstall-host.ps1 to remove everything this script sets up.
+
+.EXAMPLE
+    .\scripts\install-host.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# $IsWindows only exists on PowerShell 6+; Windows PowerShell 5.1 (no
+# $IsWindows) only ever runs on Windows anyway, so it needs no check.
+if ($PSVersionTable.PSVersion.Major -ge 6 -and -not $IsWindows) {
+    throw 'This installer is Windows-only (Firefox native messaging host registration uses the Windows registry).'
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$nativeHostDir = Join-Path $repoRoot 'native-host'
+$manifestTemplate = Join-Path $nativeHostDir 'manifests\pixels_roll20_helper.json'
+
+if (-not (Test-Path $manifestTemplate)) {
+    throw "Manifest template not found at $manifestTemplate"
+}
+
+# Prefer the explicit-target build (matches native-host/README.md and its
+# statically-linked CRT config), but fall back to a plain `cargo build
+# --release` output in case that's what the host toolchain's default
+# target already resolved to.
+$candidateExePaths = @(
+    (Join-Path $nativeHostDir 'target\x86_64-pc-windows-msvc\release\pixels-roll20-helper.exe'),
+    (Join-Path $nativeHostDir 'target\release\pixels-roll20-helper.exe')
+)
+$sourceExe = $candidateExePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+
+if (-not $sourceExe) {
+    throw "Could not find a built pixels-roll20-helper.exe. Build it first:`n  cd native-host`n  cargo build --release --target x86_64-pc-windows-msvc"
+}
+
+$installDir = Join-Path $env:LOCALAPPDATA 'PixelsRoll20'
+New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+
+$installedExe = Join-Path $installDir 'pixels-roll20-helper.exe'
+Copy-Item -Path $sourceExe -Destination $installedExe -Force
+Write-Host "Copied helper to $installedExe"
+
+$manifest = Get-Content -Path $manifestTemplate -Raw | ConvertFrom-Json
+$manifest.path = $installedExe
+$installedManifest = Join-Path $installDir 'pixels_roll20_helper.json'
+# Write UTF-8 without a BOM explicitly — PowerShell's -Encoding utf8 adds a
+# BOM on Windows PowerShell 5.1, which some JSON readers choke on.
+[System.IO.File]::WriteAllText($installedManifest, ($manifest | ConvertTo-Json -Depth 5))
+Write-Host "Wrote manifest to $installedManifest"
+
+$registryKeyPath = 'HKCU:\Software\Mozilla\NativeMessagingHosts\pixels_roll20_helper'
+New-Item -Path $registryKeyPath -Force | Out-Null
+Set-Item -Path $registryKeyPath -Value $installedManifest
+Write-Host "Registered native messaging host at $registryKeyPath"
+
+Write-Host ''
+Write-Host 'Done. Next steps:'
+Write-Host '  1. Build the Firefox extension:  npm run build:firefox'
+Write-Host '  2. In Firefox, open about:debugging#/runtime/this-firefox'
+Write-Host "  3. Click 'Load Temporary Add-on...' and select dist\firefox\manifest.json"
+Write-Host '  4. Open a Roll20 game and click Connect in the extension popup'
+Write-Host ''
+Write-Host 'To remove this later, run scripts\uninstall-host.ps1'

--- a/scripts/uninstall-host.ps1
+++ b/scripts/uninstall-host.ps1
@@ -1,0 +1,37 @@
+<#
+.SYNOPSIS
+    Removes the pixels-roll20-helper native messaging host registration
+    installed by install-host.ps1.
+
+.DESCRIPTION
+    Deletes the HKCU\Software\Mozilla\NativeMessagingHosts registry key and
+    the installed copy of the helper + manifest under
+    %LOCALAPPDATA%\PixelsRoll20\. Safe to run even if nothing is installed.
+
+.EXAMPLE
+    .\scripts\uninstall-host.ps1
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$registryKeyPath = 'HKCU:\Software\Mozilla\NativeMessagingHosts\pixels_roll20_helper'
+if (Test-Path $registryKeyPath) {
+    Remove-Item -Path $registryKeyPath -Force
+    Write-Host "Removed registry key $registryKeyPath"
+} else {
+    Write-Host "Registry key $registryKeyPath was not present"
+}
+
+$installDir = Join-Path $env:LOCALAPPDATA 'PixelsRoll20'
+if (Test-Path $installDir) {
+    Remove-Item -Path $installDir -Recurse -Force
+    Write-Host "Removed $installDir"
+} else {
+    Write-Host "$installDir was not present"
+}
+
+Write-Host ''
+Write-Host 'pixels-roll20-helper native messaging host uninstalled.'


### PR DESCRIPTION
## Summary
Implements Milestone 5 of `specs/firefox-native-messaging-support.md` — host registration and setup docs, the last piece needed to actually run the Firefox path end-to-end (native host #15, rollProcessor #16, dual-browser build #17, extension wiring #18).

- **`native-host/manifests/pixels_roll20_helper.json`**: native messaging host manifest template (name/description/path placeholder/type/`allowed_extensions`, allowlisting the fixed Firefox extension ID from the manifest patch in #17).
- **`scripts/install-host.ps1`**: copies the built exe to `%LOCALAPPDATA%\PixelsRoll20\`, writes a resolved copy of the manifest template next to it, and points Firefox at it via the `HKCU\Software\Mozilla\NativeMessagingHosts\pixels_roll20_helper` registry key. Idempotent, Windows-only guard (compatible with both Windows PowerShell 5.1 and PowerShell 7+), clear error message if the exe hasn't been built yet.
- **`scripts/uninstall-host.ps1`**: removes both, idempotently.
- **`docs/FIREFOX_SETUP.md`**: build → install → load → connect walkthrough, plus the known limitations (Windows-only, unsigned/temporary add-on, no device picker, minimal host-missing UX) carried over from the plan's explicitly-deferred items. Linked from `README.md` and `native-host/README.md` (whose "host registration is out of scope" note was now stale).

## Test plan
- [x] Ran `install-host.ps1` for real against the actual release build — confirmed the registry value and manifest content (correctly escaped Windows path, no UTF-8 BOM)
- [x] Re-ran it — confirmed idempotent (clean overwrite, no errors)
- [x] Temporarily moved the built exe aside — confirmed the "not built yet" error path gives a clear, actionable message
- [x] Ran `uninstall-host.ps1` — confirmed both the registry key and install directory are fully removed; re-ran it — confirmed idempotent
- [x] `npm test` — 270/270 passing (unaffected, no JS changes); `npm run lint` clean
- [ ] End-to-end through real Firefox (`about:debugging` → load `dist/firefox/` → connect a die) — this is the last manual verification step for the whole Firefox-support branch, now that all 5 milestones are in

🤖 Generated with [Claude Code](https://claude.com/claude-code)
