### PR TITLE
feat: Multi-dice roll grouping, auto-reconnect, and BLE die type detection

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -136,6 +136,30 @@ Simply roll your connected Pixels dice normally. The extension automatically:
 
 The extension automatically adapts the chat display based on modifier box visibility:
 
+#### Multi-Dice Roll Grouping
+
+When you roll multiple dice within a short time, the extension groups them into a single chat message showing the formula, individual results, and total:
+
+```
+Pixels Dice
+Rolling:  2d6
+Dice:     (4 + 5)
+Result:   9
+```
+
+#### Roll Window Slider
+
+The modifier box includes a **Roll window** slider (1–10 seconds) at the bottom. This controls how long the extension waits after the last die lands before posting the result. The timer resets each time a die settles, so you have the full window after your _last_ die lands.
+
+This lets you build larger formulas with fewer physical dice. For example, to roll 4d6 with only two d6 dice:
+
+1. Set the roll window to 5–6 seconds
+2. Roll your two d6 dice — they register
+3. Pick them up and roll again before the timer expires
+4. All four results are grouped into a single "4d6" message
+
+The setting is saved and persists between sessions.
+
 #### Modifier Box Visible (Detailed Mode)
 
 When the modifier box is shown, chat messages include full breakdown:
@@ -176,6 +200,27 @@ This creates a clean, uncluttered experience when you don't need modifier detail
 - Extension monitors connection status
 - Automatic reconnection attempts
 - Connection status visible in popup
+
+### Auto-Reconnect (Silent Reconnection)
+
+The extension can silently reconnect to your dice when you reload Roll20, without showing the Bluetooth chooser dialog. This requires enabling Chrome's experimental Bluetooth permissions:
+
+1. Navigate to `chrome://flags/#enable-web-bluetooth-new-permissions-backend`
+2. Set it to **Enabled**
+3. Relaunch Chrome
+
+Once enabled, the extension watches for your previously connected dice to start advertising (which happens when they wake up or are rolled). When detected, it reconnects automatically — no dialog, no clicks. You'll see the status count in the popup increment as each die comes online.
+
+**Without the flag**: The extension still remembers your dice and offers quick "Reconnect" buttons in the popup that open a pre-filtered Bluetooth chooser (showing only that specific die), reducing it to a single confirmation click.
+
+### Known Dice and Status
+
+The popup shows a "Known Dice" section listing all previously connected dice with:
+
+- **Green dot**: Die is currently connected
+- **Grey dot**: Die is remembered but not connected
+- **Reconnect**: Opens a filtered Bluetooth chooser for that specific die
+- **Forget**: Removes the die from the remembered list
 
 ## Best Practices
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixels-roll20-chrome-extension",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-roll20-chrome-extension",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "eslint": "^9.30.0",

--- a/src/components/modifierBox/componentInitializer.js
+++ b/src/components/modifierBox/componentInitializer.js
@@ -42,6 +42,7 @@ export function setupModifierBoxComponents(modifierBox, clearAllCallback) {
     setupThemeManagement(modifierBox);
     setupDragAndDrop(modifierBox);
     setupPositioning(modifierBox);
+    setupRollWindowSlider(modifierBox);
     setupCleanupHandlers();
 
     modifierBox.setAttribute('data-components-setup', 'true');
@@ -229,6 +230,46 @@ function setupDragAndDrop(modifierBox) {
   } else {
     console.warn('RowDragDrop not available - drag and drop disabled');
   }
+}
+
+function setupRollWindowSlider(modifierBox) {
+  const slider = modifierBox.querySelector('.roll-window-slider');
+  const valueDisplay = modifierBox.querySelector('.roll-window-value');
+  if (!slider || !valueDisplay) {
+    return;
+  }
+
+  // Load saved value from localStorage
+  try {
+    const saved = localStorage.getItem('pixels_roll_window_seconds');
+    if (saved) {
+      const savedValue = parseInt(saved, 10);
+      if (savedValue >= 1 && savedValue <= 10) {
+        slider.value = savedValue;
+        valueDisplay.textContent = savedValue;
+        if (window.RollBatcher) {
+          window.RollBatcher.setWindowMs(savedValue * 1000);
+        }
+      }
+    }
+  } catch {
+    // localStorage unavailable, use default
+  }
+
+  slider.addEventListener('input', () => {
+    const seconds = parseInt(slider.value, 10);
+    valueDisplay.textContent = seconds;
+
+    if (window.RollBatcher) {
+      window.RollBatcher.setWindowMs(seconds * 1000);
+    }
+
+    try {
+      localStorage.setItem('pixels_roll_window_seconds', seconds.toString());
+    } catch {
+      // localStorage unavailable
+    }
+  });
 }
 
 function setupPositioning(modifierBox) {

--- a/src/components/modifierBox/modifierBox.html
+++ b/src/components/modifierBox/modifierBox.html
@@ -50,5 +50,18 @@
       <button class="remove-row-btn" type="button">×</button>
     </div>
   </div>
+  <div class="pixels-roll-window">
+    <label class="roll-window-label">
+      Roll window: <span class="roll-window-value">2</span>s
+    </label>
+    <input
+      type="range"
+      class="roll-window-slider"
+      min="1"
+      max="10"
+      value="2"
+      step="1"
+    />
+  </div>
   <div class="pixels-resize-handle"></div>
 </div>

--- a/src/components/modifierBox/modifierBox.js
+++ b/src/components/modifierBox/modifierBox.js
@@ -228,6 +228,12 @@ function createModifierBoxFallback() {
                     <button class="remove-row-btn" type="button">×</button>
                 </div>
             </div>
+            <div class="pixels-roll-window">
+                <label class="roll-window-label">
+                    Roll window: <span class="roll-window-value">2</span>s
+                </label>
+                <input type="range" class="roll-window-slider" min="1" max="10" value="2" step="1">
+            </div>
             <div class="pixels-resize-handle"></div>
         `;
 

--- a/src/components/modifierBox/styles/modifierBox.css
+++ b/src/components/modifierBox/styles/modifierBox.css
@@ -238,6 +238,59 @@
   background-color: rgba(76, 175, 80, 0.1) !important;
 }
 
+/* Roll Window Slider */
+#pixels-modifier-box .pixels-roll-window {
+  padding: 8px 16px 12px !important;
+  border-top: 1px solid #444444 !important;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 4px !important;
+  background-color: #2b2b2b !important;
+}
+
+#pixels-modifier-box .roll-window-label {
+  font-size: 12px !important;
+  color: #cccccc !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 4px !important;
+}
+
+#pixels-modifier-box .roll-window-value {
+  font-weight: bold !important;
+  color: #4a9eff !important;
+}
+
+#pixels-modifier-box .roll-window-slider {
+  width: 100% !important;
+  height: 4px !important;
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  background: #444444 !important;
+  border-radius: 2px !important;
+  outline: none !important;
+  cursor: pointer !important;
+}
+
+#pixels-modifier-box .roll-window-slider::-webkit-slider-thumb {
+  -webkit-appearance: none !important;
+  appearance: none !important;
+  width: 14px !important;
+  height: 14px !important;
+  border-radius: 50% !important;
+  background: #4a9eff !important;
+  cursor: pointer !important;
+}
+
+#pixels-modifier-box .roll-window-slider::-moz-range-thumb {
+  width: 14px !important;
+  height: 14px !important;
+  border-radius: 50% !important;
+  background: #4a9eff !important;
+  cursor: pointer !important;
+  border: none !important;
+}
+
 /* Resize Handle */
 #pixels-modifier-box .pixels-resize-handle {
   position: absolute !important;

--- a/src/components/popup/popup.css
+++ b/src/components/popup/popup.css
@@ -431,3 +431,88 @@ body {
     animation: none;
   }
 }
+
+/* Known Dice Section */
+.known-dice-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.known-dice-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.known-dice-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background-color: #1a1a1a;
+  border: 1px solid #444444;
+  border-radius: 4px;
+  padding: 6px 8px 6px 10px;
+}
+
+.known-dice-name {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.known-dice-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background-color: #666666;
+}
+
+.known-dice-status.connected {
+  background-color: #4ade80;
+}
+
+.known-dice-item.connected {
+  border-color: #4ade80;
+}
+
+.known-dice-btn {
+  flex-shrink: 0;
+  background-color: #404040;
+  color: #ffffff;
+  border: 1px solid #555555;
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.known-dice-btn:hover {
+  background-color: #4a4a4a;
+  border-color: #666666;
+}
+
+.known-dice-btn.reconnect {
+  background-color: #1f4a2b;
+  border-color: #4ade80;
+  color: #4ade80;
+}
+
+.known-dice-btn.reconnect:hover {
+  background-color: #2a5a35;
+}
+
+.known-dice-btn.forget:hover {
+  background-color: #5a2a2a;
+  border-color: #f87171;
+  color: #f87171;
+}

--- a/src/components/popup/popup.html
+++ b/src/components/popup/popup.html
@@ -17,6 +17,14 @@
         <!-- Connection section -->
         <div class="connection-section">
           <button id="connect" class="primary-button">Connect to Pixel</button>
+          <div
+            id="knownDiceSection"
+            class="known-dice-section"
+            style="display: none"
+          >
+            <div class="section-label">Known Dice</div>
+            <ul id="knownDiceList" class="known-dice-list"></ul>
+          </div>
           <div class="connection-status">
             <div id="text" class="status-text"></div>
           </div>

--- a/src/components/popup/popup.js
+++ b/src/components/popup/popup.js
@@ -10,6 +10,7 @@ import {
   exportProfile,
   importProfiles,
 } from '../../utils/profileStorage.js';
+import { getKnownDice, removeKnownDie } from '../../utils/knownDiceStorage.js';
 
 // Simple theme detection and CSS loading
 function detectAndApplyTheme() {
@@ -155,6 +156,80 @@ function sendMessage(data, responseCallback) {
     if (tabs[0]?.id) {
       chrome.tabs.sendMessage(tabs[0].id, data, responseCallback);
     }
+  });
+}
+
+// --- Known Dice ---------------------------------------------------------------
+
+async function renderKnownDice() {
+  const section = document.getElementById('knownDiceSection');
+  const list = document.getElementById('knownDiceList');
+  if (!section || !list) {
+    return;
+  }
+
+  let dice = [];
+  try {
+    dice = await getKnownDice();
+  } catch {
+    dice = [];
+  }
+
+  if (dice.length === 0) {
+    section.style.display = 'none';
+    return;
+  }
+
+  // Query which dice are currently connected
+  const connectedNames = await new Promise(resolve => {
+    sendMessage({ action: 'getConnectedDice' }, response => {
+      if (chrome.runtime.lastError || !response) {
+        resolve([]);
+      } else {
+        resolve(response.connected || []);
+      }
+    });
+  });
+
+  section.style.display = 'flex';
+  list.innerHTML = '';
+
+  dice.forEach(die => {
+    const isConnected = connectedNames.includes(die.name);
+
+    const li = document.createElement('li');
+    li.className = isConnected
+      ? 'known-dice-item connected'
+      : 'known-dice-item';
+
+    const statusDot = document.createElement('span');
+    statusDot.className = isConnected
+      ? 'known-dice-status connected'
+      : 'known-dice-status';
+    statusDot.title = isConnected ? 'Connected' : 'Disconnected';
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'known-dice-name';
+    nameSpan.textContent = die.name;
+
+    const reconnectBtn = document.createElement('button');
+    reconnectBtn.className = 'known-dice-btn reconnect';
+    reconnectBtn.textContent = 'Reconnect';
+    reconnectBtn.onclick = () =>
+      sendMessage({ action: 'reconnect', name: die.name });
+
+    const forgetBtn = document.createElement('button');
+    forgetBtn.className = 'known-dice-btn forget';
+    forgetBtn.textContent = 'Forget';
+    forgetBtn.onclick = () => {
+      removeKnownDie(die.name).then(() => renderKnownDice());
+    };
+
+    li.appendChild(statusDot);
+    li.appendChild(nameSpan);
+    li.appendChild(reconnectBtn);
+    li.appendChild(forgetBtn);
+    list.appendChild(li);
   });
 }
 
@@ -435,6 +510,7 @@ function importProfilesFromFile(file) {
 chrome.runtime.onMessage.addListener((request, _sender, _sendResponse) => {
   if (request.action === 'showText') {
     showText(request.text);
+    renderKnownDice();
   } else if (request.action === 'modifierChanged') {
     // Store the modifier value when changed from floating box
     chrome.storage.sync.set({ modifier: request.modifier });
@@ -450,6 +526,7 @@ chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
     // Poll status every 5 seconds while popup is open to catch silent state changes
     setInterval(() => {
       sendMessage({ action: 'getStatus' });
+      renderKnownDice();
     }, 5000);
   }
 });
@@ -507,6 +584,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
   renderProfiles();
+  renderKnownDice();
 
   detectAndApplyTheme();
 });

--- a/src/content/modules/PixelsBluetooth.js
+++ b/src/content/modules/PixelsBluetooth.js
@@ -9,6 +9,7 @@
  */
 
 import { curry, pipe, map, filter, find, propEq, prop } from 'ramda';
+import { saveKnownDie } from '../../utils/knownDiceStorage.js';
 
 // Utility functions
 const log = window.log || console.log;
@@ -228,7 +229,6 @@ export const createPixel = (name, server, device) => {
       }
     } else if (ev === 1) {
       _face = face;
-      const txt = `${_name}: face up = ${face + 1}`;
 
       // Check if modifier box is visible to determine modifier application
       const isModifierBoxVisible =
@@ -249,40 +249,37 @@ export const createPixel = (name, server, device) => {
       const modifier = isModifierBoxVisible
         ? parseInt(window.pixelsModifier) || 0
         : 0;
-      const result = diceValue + modifier;
 
-      // Choose formula based on modifier box visibility
-      let formula = isModifierBoxVisible
-        ? pixelsFormulaWithModifier
-        : pixelsFormulaSimple;
+      // Route roll through the batcher for multi-dice grouping
+      const batcher = window.RollBatcher;
+      if (batcher && batcher.addRoll) {
+        const dieType = batcher.parseDieType(_name, diceValue);
+        batcher.addRoll({
+          dieName: _name,
+          dieType,
+          faceValue: diceValue,
+          modifier,
+          modifierName: window.pixelsModifierName,
+          isModifierBoxVisible,
+        });
+      } else {
+        // Fallback: post immediately if batcher unavailable
+        const result = diceValue + modifier;
+        const formula = isModifierBoxVisible
+          ? pixelsFormulaWithModifier
+          : pixelsFormulaSimple;
 
-      // Add critical hit message if face value is 20
-      if (diceValue === 20 && isModifierBoxVisible) {
-        formula = formula.replace(
-          '{{Pixel=#face_value}}',
-          '{{&#128293; <span style="color: #ff4444; font-size: 20px; font-weight: bold; text-shadow: 2px 2px 4px rgba(0,0,0,0.5);">CRITICAL!</span> &#128293;}} {{Pixel=#face_value}}'
-        );
+        const message = formula
+          .replaceAll('#modifier_name', window.pixelsModifierName)
+          .replaceAll('#modifier_sign', formatModifierSign(modifier))
+          .replaceAll('#face_value', diceValue.toString())
+          .replaceAll('#pixel_name', _name)
+          .replaceAll('#modifier', modifier.toString())
+          .replaceAll('#result', result.toString());
+
+        message.split('\\n').forEach(s => postChatMessage(s));
+        sendTextToExtension(`${_name}: face up = ${diceValue}`);
       }
-
-      // Add fumble message if face value is 1
-      if (diceValue === 1 && isModifierBoxVisible) {
-        formula = formula.replace(
-          '{{Pixel=#face_value}}',
-          '{{&#128128; <span style="color: #888888; font-size: 16px; font-style: italic; opacity: 0.7;">FUMBLE!</span> &#128128;}} {{Pixel=#face_value}}'
-        );
-      }
-
-      const message = formula
-        .replaceAll('#modifier_name', window.pixelsModifierName)
-        .replaceAll('#modifier_sign', formatModifierSign(modifier))
-        .replaceAll('#face_value', diceValue.toString())
-        .replaceAll('#pixel_name', _name)
-        .replaceAll('#modifier', modifier.toString())
-        .replaceAll('#result', result.toString());
-
-      message.split('\\n').forEach(s => postChatMessage(s));
-
-      sendTextToExtension(txt);
     }
   };
 
@@ -477,8 +474,15 @@ const connectToNewPixel = async () => {
     log(`Connected to ${device.name}`);
     sendTextToExtension(`Connected to ${device.name}`);
 
+    // Remember this die for quick reconnect in the popup
+    saveKnownDie(device.name);
+
     return pixel;
   } catch (error) {
+    if (error.name === 'NotFoundError') {
+      log('User cancelled the device chooser');
+      return null;
+    }
     log(`Connection failed: ${error.message}`);
     throw error;
   }
@@ -650,6 +654,73 @@ const attemptReconnection = async (device, pixel) => {
 // Export the main connection function
 export const connectToPixel = connectToNewPixel;
 
+// Connect to a specific die by name (filters the Bluetooth chooser)
+export const connectToPixelByName = async name => {
+  if (!navigator.bluetooth) {
+    const error = new Error('Bluetooth not supported in this browser');
+    log(error.message);
+    throw error;
+  }
+
+  const filters = [{ name }];
+
+  try {
+    const device = await navigator.bluetooth.requestDevice({
+      filters,
+      optionalServices: [PIXELS_SERVICE_UUID, PIXELS_LEGACY_SERVICE_UUID],
+    });
+
+    const existingPixel = getPixelByDeviceId(device.id, pixels);
+
+    if (existingPixel && isConnected(existingPixel)) {
+      log(`Already connected to ${device.name} (ID: ${device.id})`);
+      return existingPixel;
+    }
+
+    const server = await device.gatt.connect();
+    const notifyChar = await findNotifyCharacteristic(server);
+
+    await notifyChar.startNotifications();
+
+    let pixel;
+    if (existingPixel) {
+      existingPixel.reconnect(server, notifyChar);
+      pixel = existingPixel;
+    } else {
+      pixel = createPixel(device.name, server, device);
+      pixel.setNotifyCharacteristic(notifyChar);
+      pixels.push(pixel);
+    }
+
+    pixel.updateActivity();
+    pixel.startConnectionMonitoring();
+
+    if (!pixel._hasDisconnectListener) {
+      device.addEventListener('gattserverdisconnected', () => {
+        log(`Device ${device.name} disconnected`);
+        pixel.markDisconnected();
+        setTimeout(() => {
+          attemptReconnection(device, pixel);
+        }, 5000);
+      });
+      pixel._hasDisconnectListener = true;
+    }
+
+    log(`Connected to ${device.name}`);
+    sendTextToExtension(`Connected to ${device.name}`);
+    saveKnownDie(device.name);
+
+    return pixel;
+  } catch (error) {
+    if (error.name === 'NotFoundError') {
+      log('User cancelled the device chooser');
+      return null;
+    }
+    log(`Connection to ${name} failed: ${error.message}`);
+    throw error;
+  }
+};
+
 // Disconnect all pixels using functional approach
 export const disconnectAllPixels = () => {
   const connectedPixels = getConnectedPixels(pixels);
@@ -701,7 +772,9 @@ const setupGlobalCleanup = () => {
   }
 };
 
-// Attempt silent reconnection to previously-permitted devices
+// Attempt silent reconnection to previously-permitted devices.
+// Uses watchAdvertisements to listen indefinitely for each known die to
+// start advertising, then connects GATT and sets up notifications.
 const reconnectKnownDevices = async () => {
   if (!navigator.bluetooth || !navigator.bluetooth.getDevices) {
     log('getDevices() not available, skipping silent reconnection');
@@ -716,7 +789,7 @@ const reconnectKnownDevices = async () => {
     }
 
     log(
-      `Found ${devices.length} previously-permitted device(s), attempting reconnection`
+      `Found ${devices.length} previously-permitted device(s), watching for advertisements`
     );
 
     for (const device of devices) {
@@ -726,20 +799,83 @@ const reconnectKnownDevices = async () => {
         continue;
       }
 
-      // Create or reuse pixel entry
-      let pixel = existingPixel;
-      if (!pixel) {
-        pixel = createPixel(device.name || 'Unknown Pixel', null, device);
-        pixel._isConnected = false;
+      watchForDeviceAndConnect(device);
+    }
+  } catch (error) {
+    log(`Silent reconnection setup failed: ${error.message}`);
+  }
+};
+
+// Watch for a single device's advertisements and connect when seen.
+// The listener stays active indefinitely until the device advertises.
+const watchForDeviceAndConnect = device => {
+  const deviceName = device.name || 'Unknown Pixel';
+
+  const handleAdvertisement = async () => {
+    log(`Advertisement received from ${deviceName}, connecting...`);
+
+    // Remove this listener so we don't double-connect
+    device.removeEventListener('advertisementreceived', handleAdvertisement);
+
+    try {
+      const server = await device.gatt.connect();
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      if (!server.connected) {
+        log(`${deviceName} connection lost immediately, will keep watching`);
+        watchForDeviceAndConnect(device);
+        return;
+      }
+
+      const notifyChar = await findNotifyCharacteristic(server);
+      await notifyChar.startNotifications();
+
+      // Reuse existing pixel or create new one
+      let pixel = getPixelByDeviceId(device.id, pixels);
+      if (pixel) {
+        pixel.reconnect(server, notifyChar, device);
+      } else {
+        pixel = createPixel(deviceName, server, device);
+        pixel.setNotifyCharacteristic(notifyChar);
         pixels.push(pixel);
       }
 
-      // Attempt reconnection using dual-path strategy
-      attemptReconnection(device, pixel);
+      pixel.updateActivity();
+      pixel.startConnectionMonitoring();
+
+      if (!pixel._hasDisconnectListener) {
+        device.addEventListener('gattserverdisconnected', () => {
+          log(`Device ${deviceName} disconnected`);
+          pixel.markDisconnected();
+          // Re-watch for the device to come back
+          setTimeout(() => {
+            watchForDeviceAndConnect(device);
+          }, 2000);
+        });
+        pixel._hasDisconnectListener = true;
+      }
+
+      log(`Silently reconnected to ${deviceName}`);
+      sendTextToExtension(`Reconnected to ${deviceName}`);
+      sendStatusToExtension();
+      saveKnownDie(deviceName);
+    } catch (error) {
+      log(`Silent reconnection to ${deviceName} failed: ${error.message}`);
+      // Retry watching — the die may have stopped advertising briefly
+      setTimeout(() => {
+        watchForDeviceAndConnect(device);
+      }, 5000);
     }
-  } catch (error) {
-    log(`Silent reconnection failed: ${error.message}`);
-  }
+  };
+
+  device.addEventListener('advertisementreceived', handleAdvertisement);
+
+  device.watchAdvertisements().catch(error => {
+    if (error.name !== 'InvalidStateError') {
+      // InvalidStateError means already watching, which is fine
+      log(`watchAdvertisements failed for ${deviceName}: ${error.message}`);
+    }
+  });
 };
 
 // Initialize the module

--- a/src/content/modules/PixelsBluetooth.js
+++ b/src/content/modules/PixelsBluetooth.js
@@ -250,6 +250,7 @@ export const createPixel = (name, server, device) => {
       }
     } else if (ev === 1) {
       _face = face;
+      _hasMoved = false; // Require movement before next roll registers
 
       // Check if modifier box is visible to determine modifier application
       const isModifierBoxVisible =
@@ -266,7 +267,18 @@ export const createPixel = (name, server, device) => {
         window.ModifierBox.syncGlobalVars();
       }
 
-      const diceValue = face + 1;
+      // Calculate face value based on die type
+      // d00 (percentile): faces represent 00, 10, 20... 90
+      // d10: faces represent 0-9 as printed on the die
+      // All other dice: face index + 1
+      let diceValue;
+      if (_dieType === 100) {
+        diceValue = face === 0 ? 100 : face * 10;
+      } else if (_dieType === 10) {
+        diceValue = face;
+      } else {
+        diceValue = face + 1;
+      }
       const modifier = isModifierBoxVisible
         ? parseInt(window.pixelsModifier) || 0
         : 0;

--- a/src/content/modules/PixelsBluetooth.js
+++ b/src/content/modules/PixelsBluetooth.js
@@ -22,17 +22,31 @@ const sendStatusToExtension = window.sendStatusToExtension || function () {};
 // Modern Pixels dice UUIDs
 const PIXELS_SERVICE_UUID = 'a6b90001-7a5a-43f2-a962-350c8edc9b5b';
 const PIXELS_NOTIFY_CHARACTERISTIC = 'a6b90002-7a5a-43f2-a962-350c8edc9b5b';
-const _PIXELS_WRITE_CHARACTERISTIC = 'a6b90003-7a5a-43f2-a962-350c8edc9b5b';
+const PIXELS_WRITE_CHARACTERISTIC = 'a6b90003-7a5a-43f2-a962-350c8edc9b5b';
 
 // Legacy Pixels dice UUIDs (for older dice)
 const PIXELS_LEGACY_SERVICE_UUID = '6e400001-b5a3-f393-e0a9-e50e24dcca9e';
 const PIXELS_LEGACY_NOTIFY_CHARACTERISTIC =
   '6e400003-b5a3-f393-e0a9-e50e24dcca9e';
-const _PIXELS_LEGACY_WRITE_CHARACTERISTIC =
+const PIXELS_LEGACY_WRITE_CHARACTERISTIC =
   '6e400002-b5a3-f393-e0a9-e50e24dcca9e';
 
 // Global pixels array
 const pixels = [];
+
+// Die type enum from the Pixels BLE protocol (IAmADie message)
+const DIE_TYPE_FACES = {
+  0: 0, // Unknown
+  1: 4, // D4
+  2: 6, // D6
+  3: 8, // D8
+  4: 10, // D10
+  5: 100, // D00 (percentile)
+  6: 12, // D12
+  7: 20, // D20
+  8: 6, // D6 Pipped
+  9: 6, // D6 Fudge
+};
 
 // Reconnection strategy: 'unknown' until first attempt, then 'watch' or 'poll'
 let reconnectionStrategy = 'unknown';
@@ -76,6 +90,7 @@ export const createPixel = (name, server, device) => {
   let _connectionMonitor = null;
   let _lastActivity = Date.now();
   let _face = null;
+  let _dieType = null; // Parsed from IAmADie BLE message (number of faces)
 
   // Private methods
   const setNotifyCharacteristic = notify => {
@@ -207,13 +222,19 @@ export const createPixel = (name, server, device) => {
       _lastActivity = Date.now(); // Track activity for connection monitoring
 
       const value = event.target.value;
-      const arr = [];
-      // Convert raw data bytes to hex values just for the sake of showing something.
-      for (let i = 0; i < value.byteLength; i++) {
-        arr.push(`0x${`00${value.getUint8(i).toString(16)}`.slice(-2)}`);
-      }
 
-      if (value.getUint8(0) === 3) {
+      const messageType = value.getUint8(0);
+
+      if (messageType === 2 && value.byteLength >= 4) {
+        // IAmADie message: parse die type
+        // Legacy format: [type=2, ledCount, colorway, dieType, ...]
+        const dieTypeEnum = value.getUint8(3);
+        const faces = DIE_TYPE_FACES[dieTypeEnum] || 0;
+        if (faces > 0) {
+          _dieType = faces;
+          log(`Pixel ${_name} identified as d${faces}`);
+        }
+      } else if (messageType === 3) {
         handleFaceEvent(value.getUint8(1), value.getUint8(2));
       }
     } catch (error) {
@@ -253,7 +274,7 @@ export const createPixel = (name, server, device) => {
       // Route roll through the batcher for multi-dice grouping
       const batcher = window.RollBatcher;
       if (batcher && batcher.addRoll) {
-        const dieType = batcher.parseDieType(_name, diceValue);
+        const dieType = _dieType || batcher.parseDieType(_name, diceValue);
         batcher.addRoll({
           dieName: _name,
           dieType,
@@ -312,6 +333,9 @@ export const createPixel = (name, server, device) => {
     },
     get lastFaceUp() {
       return _face;
+    },
+    get dieType() {
+      return _dieType;
     },
     setNotifyCharacteristic,
     startConnectionMonitoring,
@@ -407,6 +431,31 @@ const findNotifyCharacteristic = async server => {
   throw new Error(
     'No Pixels notify characteristic found on device. The die may use an unsupported firmware or service UUID.'
   );
+};
+
+// Send WhoAreYou (message type 1) to request IAmADie response with die type.
+// Non-blocking: failures are silently ignored since dice may send IAmADie
+// automatically, or the die type will fall back to inference from the name/value.
+const sendWhoAreYou = async server => {
+  const writeUuids = [
+    { service: PIXELS_SERVICE_UUID, write: PIXELS_WRITE_CHARACTERISTIC },
+    {
+      service: PIXELS_LEGACY_SERVICE_UUID,
+      write: PIXELS_LEGACY_WRITE_CHARACTERISTIC,
+    },
+  ];
+
+  for (const { service: serviceUuid, write: writeUuid } of writeUuids) {
+    try {
+      const service = await server.getPrimaryService(serviceUuid);
+      const writeChar = await service.getCharacteristic(writeUuid);
+      const whoAreYou = new Uint8Array([1]); // MessageType.WhoAreYou = 1
+      await writeChar.writeValue(whoAreYou);
+      return;
+    } catch {
+      // Try next UUID pair
+    }
+  }
 };
 
 // Main Bluetooth connection logic using functional approach
@@ -682,6 +731,9 @@ export const connectToPixelByName = async name => {
 
     await notifyChar.startNotifications();
 
+    // Request die identification (triggers IAmADie response with die type)
+    sendWhoAreYou(server);
+
     let pixel;
     if (existingPixel) {
       existingPixel.reconnect(server, notifyChar);
@@ -829,6 +881,9 @@ const watchForDeviceAndConnect = device => {
 
       const notifyChar = await findNotifyCharacteristic(server);
       await notifyChar.startNotifications();
+
+      // Request die identification (triggers IAmADie response with die type)
+      sendWhoAreYou(server);
 
       // Reuse existing pixel or create new one
       let pixel = getPixelByDeviceId(device.id, pixels);

--- a/src/content/modules/RollBatcher.js
+++ b/src/content/modules/RollBatcher.js
@@ -1,0 +1,259 @@
+/**
+ * RollBatcher.js
+ *
+ * Groups individual dice roll events that occur within a short time window
+ * into a single combined roll message. When multiple Pixels dice are rolled
+ * together (e.g., two d6s), this module detects the proximity in time and
+ * produces a grouped output like "rolling 2d6 (5 + 4) = 9" instead of
+ * posting each die result separately.
+ *
+ * Single-die rolls still go through immediately after the window expires.
+ */
+
+'use strict';
+
+const ROLL_WINDOW_DEFAULT_MS = 2000;
+let rollWindowMs = ROLL_WINDOW_DEFAULT_MS;
+
+// Load saved roll window from localStorage
+try {
+  const saved = localStorage.getItem('pixels_roll_window_seconds');
+  if (saved) {
+    const parsed = parseInt(saved, 10);
+    if (parsed >= 1 && parsed <= 10) {
+      rollWindowMs = parsed * 1000;
+    }
+  }
+} catch {
+  // localStorage unavailable, use default
+}
+
+// Resolve dependencies lazily at call time to avoid load-order issues
+function getPostChatMessage() {
+  return window.postChatMessage || function () {};
+}
+
+function getSendTextToExtension() {
+  return window.sendTextToExtension || function () {};
+}
+
+/**
+ * Parse die type (number of faces) from a Pixel die name.
+ * Pixels dice are typically named like "PixelD6_XXXX", "MyD20", etc.
+ * Falls back to inferring from the rolled value when name doesn't help.
+ */
+function parseDieType(dieName, faceValue) {
+  const match = dieName.match(/d(\d+)/i);
+  if (match) {
+    return parseInt(match[1], 10);
+  }
+  return inferDieSize(faceValue);
+}
+
+/**
+ * Infer die size from a face value when the name doesn't contain type info.
+ * Uses standard RPG die sizes.
+ */
+function inferDieSize(faceValue) {
+  const standardDice = [4, 6, 8, 10, 12, 20, 100];
+  for (const size of standardDice) {
+    if (faceValue <= size) {
+      return size;
+    }
+  }
+  return 20;
+}
+
+// Batched roll entries
+let pendingRolls = [];
+let batchTimer = null;
+
+/**
+ * Add a roll to the current batch. If this is the first roll, start the
+ * grouping timer. When the timer fires, flush all collected rolls.
+ */
+function addRoll(rollData) {
+  pendingRolls.push(rollData);
+
+  if (batchTimer !== null) {
+    clearTimeout(batchTimer);
+  }
+  batchTimer = setTimeout(flushRolls, rollWindowMs);
+}
+
+/**
+ * Flush all pending rolls as either a single roll message or a grouped message.
+ */
+function flushRolls() {
+  batchTimer = null;
+  const rolls = pendingRolls.slice();
+  pendingRolls = [];
+
+  if (rolls.length === 0) {
+    return;
+  }
+
+  if (rolls.length === 1) {
+    postSingleRoll(rolls[0]);
+  } else {
+    postGroupedRoll(rolls);
+  }
+}
+
+/**
+ * Post a single-die roll (preserves current behavior).
+ */
+function postSingleRoll(roll) {
+  const {
+    dieName,
+    dieType,
+    faceValue,
+    modifier,
+    modifierName,
+    isModifierBoxVisible,
+  } = roll;
+
+  let formula;
+  if (isModifierBoxVisible && modifier !== 0) {
+    formula = buildSingleWithModifierFormula(
+      faceValue,
+      modifier,
+      modifierName,
+      dieType,
+      dieName
+    );
+  } else {
+    formula = buildSingleSimpleFormula(faceValue, dieType, dieName);
+  }
+
+  formula.split('\\n').forEach(s => getPostChatMessage()(s));
+  getSendTextToExtension()(`${dieName}: face up = ${faceValue}`);
+}
+
+/**
+ * Post a grouped multi-dice roll with formula, individual results, and sum.
+ */
+function postGroupedRoll(rolls) {
+  const firstRoll = rolls[0];
+  const { modifier, modifierName, isModifierBoxVisible } = firstRoll;
+
+  const rollsByType = groupRollsByDieType(rolls);
+  const totalDiceValue = rolls.reduce((sum, r) => sum + r.faceValue, 0);
+
+  const formulaParts = buildDiceFormulaParts(rollsByType);
+  const individualValues = rolls
+    .map(r => `<span title="${r.dieName}">${r.faceValue}</span>`)
+    .join(' + ');
+
+  let message;
+  if (isModifierBoxVisible && modifier !== 0) {
+    const modifierSign = formatModifierSign(modifier);
+    const diceExpr = rolls.map(r => r.faceValue).join('+');
+    message =
+      `&{template:default} {{name=${modifierName} (Pixels Dice)}}` +
+      ` {{Rolling=${formulaParts}${modifierSign}}}` +
+      ` {{Dice=( ${individualValues} ) ${modifierSign}}}` +
+      ` {{Result=[[(${diceExpr})+${modifier}[${modifierName}]]]}}`;
+  } else {
+    // Use inline roll so hover shows: Rolling (2+5+6+4+2) = 19
+    const diceExpr = rolls.map(r => r.faceValue).join('+');
+    message =
+      `&{template:default} {{name=Pixels Dice}}` +
+      ` {{Rolling=${formulaParts}}}` +
+      ` {{Dice=( ${individualValues} )}}` +
+      ` {{Result=[[(${diceExpr})]]}}`;
+  }
+
+  getPostChatMessage()(message);
+
+  const diceNames = rolls.map(r => r.dieName).join(', ');
+  getSendTextToExtension()(`${diceNames}: ${formulaParts} = ${totalDiceValue}`);
+}
+
+/**
+ * Group rolls by die type and return counts, e.g. { 6: [5, 4], 20: [17] }
+ */
+function groupRollsByDieType(rolls) {
+  const groups = {};
+  for (const roll of rolls) {
+    const type = roll.dieType;
+    if (!groups[type]) {
+      groups[type] = [];
+    }
+    groups[type].push(roll.faceValue);
+  }
+  return groups;
+}
+
+/**
+ * Build the dice formula string like "2d6" or "2d6 + 1d8".
+ */
+function buildDiceFormulaParts(rollsByType) {
+  const sortedTypes = Object.keys(rollsByType)
+    .map(Number)
+    .sort((a, b) => a - b);
+  return sortedTypes
+    .map(type => `${rollsByType[type].length}d${type}`)
+    .join(' + ');
+}
+
+/**
+ * Build a single-die formula with modifier (matches existing format).
+ */
+function buildSingleWithModifierFormula(
+  faceValue,
+  modifier,
+  modifierName,
+  dieType,
+  dieName
+) {
+  const modifierSign = formatModifierSign(modifier);
+  const diceWithHover = `<span title="${dieName}">${faceValue}</span>`;
+  return (
+    `&{template:default} {{name=${modifierName} (Pixels Dice)}}` +
+    ` {{Rolling=1d${dieType}${modifierSign}}}` +
+    ` {{Dice=${diceWithHover} ${modifierSign}}}` +
+    ` {{Result=[[${faceValue}+${modifier}[${modifierName}]]]}}`
+  );
+}
+
+/**
+ * Build a single-die formula without modifier (matches existing format).
+ */
+function buildSingleSimpleFormula(faceValue, dieType, dieName) {
+  const diceWithHover = `<span title="${dieName}">${faceValue}</span>`;
+  return (
+    `&{template:default} {{name=Pixels Dice}}` +
+    ` {{Rolling=1d${dieType}}}` +
+    ` {{Dice=${diceWithHover}}}` +
+    ` {{Result=[[${faceValue}]]}}`
+  );
+}
+
+function formatModifierSign(modifier) {
+  const num = parseInt(modifier, 10) || 0;
+  return num >= 0 ? `+${num}` : num.toString();
+}
+
+/**
+ * Update the roll batching window duration.
+ */
+function setWindowMs(ms) {
+  rollWindowMs = ms;
+}
+
+// Public API
+const RollBatcher = {
+  addRoll,
+  parseDieType,
+  flushRolls,
+  setWindowMs,
+};
+
+export { addRoll, parseDieType, flushRolls, setWindowMs };
+export default RollBatcher;
+
+// Global export for backward compatibility with content script loading
+if (typeof window !== 'undefined') {
+  window.RollBatcher = RollBatcher;
+}

--- a/src/content/modules/RollBatcher.js
+++ b/src/content/modules/RollBatcher.js
@@ -134,6 +134,61 @@ function postSingleRoll(roll) {
  * Post a grouped multi-dice roll with formula, individual results, and sum.
  */
 function postGroupedRoll(rolls) {
+  // Detect percentile combo: exactly one d% and one d10
+  const percentileRolls = rolls.filter(r => r.dieType === 100);
+  const d10Rolls = rolls.filter(r => r.dieType === 10);
+  const otherRolls = rolls.filter(r => r.dieType !== 100 && r.dieType !== 10);
+
+  if (percentileRolls.length === 1 && d10Rolls.length === 1) {
+    const percentileResult = computePercentileValue(
+      percentileRolls[0].faceValue,
+      d10Rolls[0].faceValue
+    );
+    // Combine into a single virtual "d%" roll
+    const combinedRolls = [
+      ...otherRolls,
+      {
+        dieName: `${percentileRolls[0].dieName}+${d10Rolls[0].dieName}`,
+        dieType: 101, // Special marker for combined percentile
+        faceValue: percentileResult,
+        modifier: rolls[0].modifier,
+        modifierName: rolls[0].modifierName,
+        isModifierBoxVisible: rolls[0].isModifierBoxVisible,
+      },
+    ];
+
+    if (combinedRolls.length === 1) {
+      postSingleRoll(combinedRolls[0]);
+      const diceNames = `${percentileRolls[0].dieName}, ${d10Rolls[0].dieName}`;
+      getSendTextToExtension()(`${diceNames}: d% = ${percentileResult}`);
+      return;
+    }
+    // If there are other dice beyond the percentile pair, post as grouped
+    postGroupedRollFromList(combinedRolls);
+    return;
+  }
+
+  postGroupedRollFromList(rolls);
+}
+
+/**
+ * Compute percentile value from d% and d10 face values.
+ * d%=100 (the "00" face), d10=0 → 100; d%=100, d10=X → X; otherwise d%+d10.
+ */
+function computePercentileValue(percentileFace, d10Face) {
+  if (percentileFace === 100 && d10Face === 0) {
+    return 100;
+  }
+  if (percentileFace === 100) {
+    return d10Face;
+  }
+  return percentileFace + d10Face;
+}
+
+/**
+ * Post a grouped roll from a pre-processed list of rolls.
+ */
+function postGroupedRollFromList(rolls) {
   const firstRoll = rolls[0];
   const { modifier, modifierName, isModifierBoxVisible } = firstRoll;
 
@@ -141,22 +196,24 @@ function postGroupedRoll(rolls) {
   const totalDiceValue = rolls.reduce((sum, r) => sum + r.faceValue, 0);
 
   const formulaParts = buildDiceFormulaParts(rollsByType);
-  const individualValues = rolls
+
+  // Sort rolls by die type to match the formula ordering
+  const sortedRolls = [...rolls].sort((a, b) => a.dieType - b.dieType);
+  const individualValues = sortedRolls
     .map(r => `<span title="${r.dieName}">${r.faceValue}</span>`)
     .join(' + ');
 
   let message;
   if (isModifierBoxVisible && modifier !== 0) {
     const modifierSign = formatModifierSign(modifier);
-    const diceExpr = rolls.map(r => r.faceValue).join('+');
+    const diceExpr = sortedRolls.map(r => r.faceValue).join('+');
     message =
       `&{template:default} {{name=${modifierName} (Pixels Dice)}}` +
       ` {{Rolling=${formulaParts}${modifierSign}}}` +
       ` {{Dice=( ${individualValues} ) ${modifierSign}}}` +
       ` {{Result=[[(${diceExpr})+${modifier}[${modifierName}]]]}}`;
   } else {
-    // Use inline roll so hover shows: Rolling (2+5+6+4+2) = 19
-    const diceExpr = rolls.map(r => r.faceValue).join('+');
+    const diceExpr = sortedRolls.map(r => r.faceValue).join('+');
     message =
       `&{template:default} {{name=Pixels Dice}}` +
       ` {{Rolling=${formulaParts}}}` +
@@ -193,7 +250,17 @@ function buildDiceFormulaParts(rollsByType) {
     .map(Number)
     .sort((a, b) => a - b);
   return sortedTypes
-    .map(type => `${rollsByType[type].length}d${type}`)
+    .map(type => {
+      let label;
+      if (type === 101) {
+        label = 'd%';
+      } else if (type === 100) {
+        label = 'd00';
+      } else {
+        label = `d${type}`;
+      }
+      return `${rollsByType[type].length}${label}`;
+    })
     .join(' + ');
 }
 
@@ -209,9 +276,11 @@ function buildSingleWithModifierFormula(
 ) {
   const modifierSign = formatModifierSign(modifier);
   const diceWithHover = `<span title="${dieName}">${faceValue}</span>`;
+  const dieLabel =
+    dieType === 101 ? 'd%' : dieType === 100 ? 'd00' : `d${dieType}`;
   return (
     `&{template:default} {{name=${modifierName} (Pixels Dice)}}` +
-    ` {{Rolling=1d${dieType}${modifierSign}}}` +
+    ` {{Rolling=1${dieLabel}${modifierSign}}}` +
     ` {{Dice=${diceWithHover} ${modifierSign}}}` +
     ` {{Result=[[${faceValue}+${modifier}[${modifierName}]]]}}`
   );
@@ -222,9 +291,11 @@ function buildSingleWithModifierFormula(
  */
 function buildSingleSimpleFormula(faceValue, dieType, dieName) {
   const diceWithHover = `<span title="${dieName}">${faceValue}</span>`;
+  const dieLabel =
+    dieType === 101 ? 'd%' : dieType === 100 ? 'd00' : `d${dieType}`;
   return (
     `&{template:default} {{name=Pixels Dice}}` +
-    ` {{Rolling=1d${dieType}}}` +
+    ` {{Rolling=1${dieLabel}}}` +
     ` {{Dice=${diceWithHover}}}` +
     ` {{Result=[[${faceValue}]]}}`
   );

--- a/src/content/roll20.js
+++ b/src/content/roll20.js
@@ -8,6 +8,7 @@
 import {
   initialize as initializePixelsBluetooth,
   connectToPixel,
+  connectToPixelByName,
   disconnectAllPixels,
   getPixels,
 } from './modules/PixelsBluetooth.js';
@@ -35,6 +36,7 @@ if (typeof window.roll20PixelsLoaded === 'undefined') {
 
     // Expose functions to global scope for backwards compatibility
     window.connectToPixel = connectToPixel;
+    window.connectToPixelByName = connectToPixelByName;
     window.disconnectAllPixels = disconnectAllPixels;
     window.getPixels = getPixels;
     window.sendTextToExtension = sendTextToExtension;
@@ -168,9 +170,33 @@ if (typeof window.roll20PixelsLoaded === 'undefined') {
               })();
               break;
 
+            case 'reconnect':
+              // Reconnect to a specific die by name (filtered Bluetooth chooser)
+              (async () => {
+                try {
+                  await connectToPixelByName(msg.name);
+                } catch (error) {
+                  log(`Error reconnecting to ${msg.name}: ${error.message}`);
+                  if (typeof window.sendTextToExtension === 'function') {
+                    window.sendTextToExtension(
+                      `Failed to reconnect to ${msg.name}: ${error.message}`
+                    );
+                  }
+                }
+              })();
+              break;
+
             case 'disconnect':
               disconnectAllPixels();
               break;
+
+            case 'getConnectedDice': {
+              const connectedNames = getPixels()
+                .filter(p => p.isConnected)
+                .map(p => p.name);
+              sendResponse({ connected: connectedNames });
+              return true;
+            }
 
             case 'getTheme': {
               // Get current theme from ThemeDetector

--- a/src/core/extensionMessaging.js
+++ b/src/core/extensionMessaging.js
@@ -4,6 +4,7 @@
  */
 
 import { filter } from 'ramda';
+import { getKnownDice } from '../utils/knownDiceStorage.js';
 
 // Message handler for extension communication
 export const sendMessageToExtension = data => {
@@ -32,27 +33,36 @@ export const sendTextToExtension = txt => {
   sendMessageToExtension({ action: 'showText', text: txt });
 };
 
-export const sendStatusToExtension = () => {
+export const sendStatusToExtension = async () => {
   const pixels = window.pixels || [];
 
   // Verify actual GATT state for each pixel, not just cached _isConnected
   const connectedPixels = filter(p => {
     try {
-      return p.isConnected && p.device && p.device.gatt && p.device.gatt.connected;
+      return (
+        p.isConnected && p.device && p.device.gatt && p.device.gatt.connected
+      );
     } catch {
       return false;
     }
   }, pixels);
-  const totalPixels = pixels.length;
 
-  if (totalPixels === 0) {
-    sendTextToExtension('No Pixel connected');
-  } else if (totalPixels === 1) {
-    const status = connectedPixels.length === 1 ? 'connected' : 'disconnected';
-    sendTextToExtension(`1 Pixel ${status}`);
+  // Use known dice count as the total so status shows progress toward full reconnection
+  let knownTotal = 0;
+  try {
+    const knownDice = await getKnownDice();
+    knownTotal = knownDice.length;
+  } catch {
+    knownTotal = 0;
+  }
+
+  const totalToShow = Math.max(knownTotal, pixels.length);
+
+  if (totalToShow === 0) {
+    sendTextToExtension('No Pixels connected');
   } else {
     sendTextToExtension(
-      `${connectedPixels.length}/${totalPixels} Pixels connected`
+      `${connectedPixels.length}/${totalToShow} Pixels connected`
     );
   }
 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,6 +41,7 @@
         "content/modules/Utils.js",
         "content/modules/PopupDetection.js",
         "content/modules/Roll20Integration.js",
+        "content/modules/RollBatcher.js",
         "content/modules/StorageManager.js",
         "content/modules/ModifierBoxManager.js",
         "content/modules/PixelsBluetooth.js",

--- a/src/utils/knownDiceStorage.js
+++ b/src/utils/knownDiceStorage.js
@@ -1,0 +1,62 @@
+/**
+ * knownDiceStorage.js
+ *
+ * Persists previously connected Pixels dice names to chrome.storage.local
+ * so the popup can offer quick reconnect buttons.
+ */
+
+'use strict';
+
+const STORAGE_KEY = 'pixels_known_dice';
+
+/**
+ * Retrieve the list of known dice from storage.
+ * Returns an array of { name, lastConnected } objects sorted by most recent.
+ */
+export function getKnownDice() {
+  return new Promise(resolve => {
+    if (typeof chrome === 'undefined' || !chrome.storage) {
+      resolve([]);
+      return;
+    }
+    chrome.storage.local.get(STORAGE_KEY, result => {
+      const dice = result[STORAGE_KEY] || [];
+      resolve(dice);
+    });
+  });
+}
+
+/**
+ * Add or update a die in the known dice list.
+ * Moves existing entries to the top (most recently connected).
+ */
+export function saveKnownDie(name) {
+  return new Promise(resolve => {
+    if (typeof chrome === 'undefined' || !chrome.storage) {
+      resolve();
+      return;
+    }
+    chrome.storage.local.get(STORAGE_KEY, result => {
+      const dice = result[STORAGE_KEY] || [];
+      const filtered = dice.filter(d => d.name !== name);
+      filtered.unshift({ name, lastConnected: Date.now() });
+      chrome.storage.local.set({ [STORAGE_KEY]: filtered }, resolve);
+    });
+  });
+}
+
+/**
+ * Remove a die from the known dice list.
+ */
+export function removeKnownDie(name) {
+  return new Promise(resolve => {
+    if (typeof chrome === 'undefined' || !chrome.storage) {
+      resolve();
+      return;
+    }
+    chrome.storage.local.get(STORAGE_KEY, result => {
+      const dice = (result[STORAGE_KEY] || []).filter(d => d.name !== name);
+      chrome.storage.local.set({ [STORAGE_KEY]: dice }, resolve);
+    });
+  });
+}

--- a/tests/jest/roll20.test.js
+++ b/tests/jest/roll20.test.js
@@ -353,7 +353,7 @@ describe('Roll20.js - Comprehensive Tests', () => {
       // Status is sent automatically on module load
       expect(mockChrome.runtime.sendMessage).toHaveBeenCalledWith({
         action: 'showText',
-        text: 'No Pixel connected',
+        text: 'No Pixels connected',
       });
     });
   });

--- a/tests/jest/rollBatcher.test.js
+++ b/tests/jest/rollBatcher.test.js
@@ -1,0 +1,306 @@
+/**
+ * RollBatcher Module Tests
+ *
+ * Tests for the roll batching system that groups individual dice rolls
+ * within a time window into combined messages.
+ */
+
+// Mock globals before requiring the module
+global.window = {
+  postChatMessage: jest.fn(),
+  sendTextToExtension: jest.fn(),
+  RollBatcher: null,
+};
+
+global.localStorage = {
+  getItem: jest.fn(() => null),
+  setItem: jest.fn(),
+};
+
+describe('RollBatcher', () => {
+  let RollBatcher;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    global.window.postChatMessage = jest.fn();
+    global.window.sendTextToExtension = jest.fn();
+    global.localStorage.getItem = jest.fn(() => null);
+
+    // Re-require to get a fresh module instance
+    jest.resetModules();
+    RollBatcher = require('../../src/content/modules/RollBatcher.js');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('parseDieType', () => {
+    test('should parse d6 from die name containing "d6"', () => {
+      expect(RollBatcher.parseDieType('PixelD6_ABC', 3)).toBe(6);
+    });
+
+    test('should parse d20 from die name containing "d20"', () => {
+      expect(RollBatcher.parseDieType('MG d20', 15)).toBe(20);
+    });
+
+    test('should parse d12 from die name case-insensitively', () => {
+      expect(RollBatcher.parseDieType('MyD12Die', 7)).toBe(12);
+    });
+
+    test('should infer d6 from face value 5 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('RandomName', 5)).toBe(6);
+    });
+
+    test('should infer d4 from face value 4 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('NoDiceInfo', 4)).toBe(4);
+    });
+
+    test('should infer d20 from face value 13 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('UUID-1234', 13)).toBe(20);
+    });
+
+    test('should infer d8 from face value 7 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('SomeDie', 7)).toBe(8);
+    });
+
+    test('should infer d10 from face value 9 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('SomeDie', 9)).toBe(10);
+    });
+
+    test('should infer d12 from face value 11 when name has no die type', () => {
+      expect(RollBatcher.parseDieType('SomeDie', 11)).toBe(12);
+    });
+
+    test('should default to d20 for values above 100', () => {
+      expect(RollBatcher.parseDieType('Unknown', 150)).toBe(20);
+    });
+  });
+
+  describe('setWindowMs', () => {
+    test('should change the batch window duration', () => {
+      const rollData = createRollData('Die1', 6, 3);
+
+      RollBatcher.setWindowMs(5000);
+      RollBatcher.addRoll(rollData);
+
+      // Should not flush at 2 seconds
+      jest.advanceTimersByTime(2000);
+      expect(global.window.postChatMessage).not.toHaveBeenCalled();
+
+      // Should flush at 5 seconds
+      jest.advanceTimersByTime(3000);
+      expect(global.window.postChatMessage).toHaveBeenCalled();
+    });
+  });
+
+  describe('addRoll and flushRolls', () => {
+    test('should post a single roll after the timer expires', () => {
+      const rollData = createRollData('Die1', 6, 4);
+
+      RollBatcher.addRoll(rollData);
+
+      // Should not have posted yet
+      expect(global.window.postChatMessage).not.toHaveBeenCalled();
+
+      // Advance past the default 2-second window
+      jest.advanceTimersByTime(2000);
+
+      expect(global.window.postChatMessage).toHaveBeenCalledTimes(1);
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('Pixels Dice');
+      expect(message).toContain('1d6');
+    });
+
+    test('should group multiple rolls within the window', () => {
+      RollBatcher.addRoll(createRollData('Die1', 6, 4));
+      jest.advanceTimersByTime(500);
+      RollBatcher.addRoll(createRollData('Die2', 6, 3));
+
+      jest.advanceTimersByTime(2000);
+
+      expect(global.window.postChatMessage).toHaveBeenCalledTimes(1);
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('2d6');
+      expect(message).toContain('Pixels Dice');
+    });
+
+    test('should reset timer on each new roll', () => {
+      RollBatcher.addRoll(createRollData('Die1', 6, 4));
+
+      jest.advanceTimersByTime(1500);
+      // Add second roll before first timer fires
+      RollBatcher.addRoll(createRollData('Die2', 6, 2));
+
+      // First timer would have fired at 2000ms, but it was reset
+      jest.advanceTimersByTime(500);
+      expect(global.window.postChatMessage).not.toHaveBeenCalled();
+
+      // Should flush 2000ms after the second roll
+      jest.advanceTimersByTime(1500);
+      expect(global.window.postChatMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test('should include modifier in output when non-zero', () => {
+      const rollData = createRollData('Die1', 20, 15, {
+        modifier: 3,
+        modifierName: 'Attack',
+        isModifierBoxVisible: true,
+      });
+
+      RollBatcher.addRoll(rollData);
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('Attack (Pixels Dice)');
+      expect(message).toContain('+3');
+    });
+
+    test('should not include modifier when zero', () => {
+      const rollData = createRollData('Die1', 20, 15, {
+        modifier: 0,
+        modifierName: 'Modifier',
+        isModifierBoxVisible: true,
+      });
+
+      RollBatcher.addRoll(rollData);
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('Pixels Dice');
+      expect(message).not.toContain('+0');
+    });
+
+    test('should handle mixed die types in a group', () => {
+      RollBatcher.addRoll(createRollData('D6Die', 6, 5));
+      RollBatcher.addRoll(createRollData('D8Die', 8, 7));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('1d6');
+      expect(message).toContain('1d8');
+    });
+
+    test('should sort dice values by die type in output', () => {
+      // Add d8 first, then d6
+      RollBatcher.addRoll(createRollData('D8Die', 8, 7));
+      RollBatcher.addRoll(createRollData('D6Die', 6, 3));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      // Formula should list d6 before d8
+      expect(message.indexOf('1d6')).toBeLessThan(message.indexOf('1d8'));
+    });
+
+    test('should send text to extension for each roll', () => {
+      RollBatcher.addRoll(createRollData('MyDie', 6, 4));
+      jest.advanceTimersByTime(2000);
+
+      expect(global.window.sendTextToExtension).toHaveBeenCalled();
+    });
+  });
+
+  describe('percentile combo detection', () => {
+    test('should combine d00 and d10 into a d% roll', () => {
+      RollBatcher.addRoll(createRollData('D00Die', 100, 30));
+      RollBatcher.addRoll(createRollData('D10Die', 10, 5));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('d%');
+      expect(message).toContain('35');
+    });
+
+    test('should handle d00=100 and d10=0 as 100', () => {
+      RollBatcher.addRoll(createRollData('D00Die', 100, 100));
+      RollBatcher.addRoll(createRollData('D10Die', 10, 0));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('100');
+    });
+
+    test('should handle d00=100 and d10=5 as 5', () => {
+      RollBatcher.addRoll(createRollData('D00Die', 100, 100));
+      RollBatcher.addRoll(createRollData('D10Die', 10, 5));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      // Result should be 5, not 105
+      expect(message).toContain('[[5]]');
+    });
+
+    test('should display standalone d00 as d00 not d%', () => {
+      RollBatcher.addRoll(createRollData('D00Die', 100, 50));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('d00');
+      expect(message).not.toContain('d%');
+    });
+
+    test('should combine d00+d10 with other dice in the batch', () => {
+      RollBatcher.addRoll(createRollData('D00Die', 100, 40));
+      RollBatcher.addRoll(createRollData('D10Die', 10, 3));
+      RollBatcher.addRoll(createRollData('D6Die', 6, 5));
+
+      jest.advanceTimersByTime(2000);
+
+      const message = global.window.postChatMessage.mock.calls[0][0];
+      expect(message).toContain('d%');
+      expect(message).toContain('1d6');
+    });
+  });
+
+  describe('flushRolls', () => {
+    test('should do nothing when no rolls are pending', () => {
+      RollBatcher.flushRolls();
+      expect(global.window.postChatMessage).not.toHaveBeenCalled();
+    });
+
+    test('should flush pending rolls immediately when called', () => {
+      RollBatcher.addRoll(createRollData('Die1', 6, 4));
+
+      // Flush manually before timer
+      RollBatcher.flushRolls();
+
+      expect(global.window.postChatMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    test('should respect custom window set via setWindowMs', () => {
+      RollBatcher.setWindowMs(5000);
+
+      const rollData = createRollData('Die1', 6, 3);
+      RollBatcher.addRoll(rollData);
+
+      jest.advanceTimersByTime(4000);
+      expect(global.window.postChatMessage).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1000);
+      expect(global.window.postChatMessage).toHaveBeenCalled();
+    });
+  });
+});
+
+/**
+ * Helper to create roll data objects for testing.
+ */
+function createRollData(dieName, dieType, faceValue, options = {}) {
+  return {
+    dieName,
+    dieType,
+    faceValue,
+    modifier: options.modifier || 0,
+    modifierName: options.modifierName || 'Modifier',
+    isModifierBoxVisible: options.isModifierBoxVisible || false,
+  };
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
     'content/modules/PopupDetection': './src/content/modules/PopupDetection.js',
     'content/modules/Roll20Integration':
       './src/content/modules/Roll20Integration.js',
+    'content/modules/RollBatcher': './src/content/modules/RollBatcher.js',
     'content/modules/StorageManager': './src/content/modules/StorageManager.js',
     'content/modules/ModifierBoxManager':
       './src/content/modules/ModifierBoxManager.js',


### PR DESCRIPTION
## Summary

Adds multi-dice roll grouping, silent Bluetooth reconnection, and proper die type detection from the Pixels BLE protocol.

## Changes

**Multi-dice roll grouping**
- New RollBatcher module collects dice rolls within a configurable time window
- Displays formula (e.g., 2d6), individual results, and sum in a single chat message
- Configurable batch window (1-10s) via slider in the modifier box
- Proper d00/d10 percentile combo detection (d%+d10 = combined value)
- Die values sorted by type to match formula ordering

**Auto-reconnect and known dice**
- Remember previously connected dice in chrome.storage.local
- Silent reconnection via watchAdvertisements (requires Chrome BLE permissions flag)
- Known Dice section in popup with per-die connection status (green/grey dots)
- Quick reconnect buttons with name-filtered Bluetooth chooser
- Graceful handling of cancelled Bluetooth chooser dialog

**BLE die type detection**
- Parse IAmADie message (type 2) from Pixels protocol for actual face count
- Send WhoAreYou (type 1) after connection to trigger identification
- Correct face value calculation for d00 (x10) and d10 (0-9)
- Falls back to name-based inference when BLE response unavailable

**UX improvements**
- Status shows connected/total using known dice count (e.g., 3/10)
- Popup refreshes connection status on poll and status messages
- Title bar shows "Pixels Dice" or "ModifierName (Pixels Dice)"
- Modifier omitted from output when zero

## Testing

- 243 tests passing (27 new for RollBatcher)
- Lint clean, build clean
- Manually tested with 10 Pixels dice (d4, d6, d8, d10, d00, d12, d20)

## Checklist

- [x] Extension loads without errors
- [x] No console errors
- [x] All tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Multi-device Bluetooth tested
